### PR TITLE
Add functionality to update timer entries via tvheadend PVR client

### DIFF
--- a/xbmc/pvrclients/tvheadend/HTSPData.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPData.cpp
@@ -434,6 +434,33 @@ PVR_ERROR cHTSPData::AddTimer(const PVR_TIMERINFO &timerinfo)
   return success > 0 ? PVR_ERROR_NO_ERROR : PVR_ERROR_NOT_DELETED;
 }
 
+PVR_ERROR cHTSPData::UpdateTimer(const PVR_TIMERINFO &timerinfo)
+{
+  XBMC->Log(LOG_DEBUG, "%s - id=%d", __FUNCTION__, timerinfo.index);
+
+  htsmsg_t *msg = htsmsg_create_map();
+  htsmsg_add_str(msg, "method", "updateDvrEntry");
+  htsmsg_add_u32(msg, "id", timerinfo.index);
+  htsmsg_add_str(msg, "title", timerinfo.title);
+  htsmsg_add_u32(msg, "start", timerinfo.starttime);
+  htsmsg_add_u32(msg, "stop", timerinfo.endtime);
+  
+  if ((msg = ReadResult(msg)) == NULL)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - Failed to get updateDvrEntry", __FUNCTION__);
+    return PVR_ERROR_SERVER_ERROR;
+  }
+
+  unsigned int success;
+  if (htsmsg_get_u32(msg, "success", &success) != 0)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - Failed to parse param", __FUNCTION__);
+    return PVR_ERROR_SERVER_ERROR;
+  }
+
+  return success > 0 ? PVR_ERROR_NO_ERROR : PVR_ERROR_NOT_SAVED;
+}
+
 void cHTSPData::Action()
 {
   XBMC->Log(LOG_DEBUG, "%s - Starting", __FUNCTION__);

--- a/xbmc/pvrclients/tvheadend/HTSPData.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPData.cpp
@@ -461,6 +461,32 @@ PVR_ERROR cHTSPData::UpdateTimer(const PVR_TIMERINFO &timerinfo)
   return success > 0 ? PVR_ERROR_NO_ERROR : PVR_ERROR_NOT_SAVED;
 }
 
+PVR_ERROR cHTSPData::RenameRecording(const PVR_RECORDINGINFO &recinfo, const char* newname)
+{
+  XBMC->Log(LOG_DEBUG, "%s - id=%d", __FUNCTION__, recinfo.index);
+
+  htsmsg_t *msg = htsmsg_create_map();
+  htsmsg_add_str(msg, "method", "updateDvrEntry");
+  htsmsg_add_u32(msg, "id", recinfo.index);
+  htsmsg_add_str(msg, "title", newname);
+  
+  if ((msg = ReadResult(msg)) == NULL)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - Failed to get updateDvrEntry", __FUNCTION__);
+    return PVR_ERROR_SERVER_ERROR;
+  }
+
+  unsigned int success;
+  if (htsmsg_get_u32(msg, "success", &success) != 0)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - Failed to parse param", __FUNCTION__);
+    return PVR_ERROR_SERVER_ERROR;
+  }
+
+  return success > 0 ? PVR_ERROR_NO_ERROR : PVR_ERROR_NOT_SAVED;
+}
+
+
 void cHTSPData::Action()
 {
   XBMC->Log(LOG_DEBUG, "%s - Starting", __FUNCTION__);

--- a/xbmc/pvrclients/tvheadend/HTSPData.h
+++ b/xbmc/pvrclients/tvheadend/HTSPData.h
@@ -48,6 +48,7 @@ public:
   PVR_ERROR RequestRecordingsList(PVRHANDLE handle);
   PVR_ERROR DeleteRecording(const PVR_RECORDINGINFO &recinfo);
   PVR_ERROR AddTimer(const PVR_TIMERINFO &timerinfo);
+  PVR_ERROR UpdateTimer(const PVR_TIMERINFO &timerinfo);
 
   int GetNumTimers();
   PVR_ERROR RequestTimerList(PVRHANDLE handle);

--- a/xbmc/pvrclients/tvheadend/HTSPData.h
+++ b/xbmc/pvrclients/tvheadend/HTSPData.h
@@ -49,6 +49,7 @@ public:
   PVR_ERROR DeleteRecording(const PVR_RECORDINGINFO &recinfo);
   PVR_ERROR AddTimer(const PVR_TIMERINFO &timerinfo);
   PVR_ERROR UpdateTimer(const PVR_TIMERINFO &timerinfo);
+  PVR_ERROR RenameRecording(const PVR_RECORDINGINFO &recinfo, const char* newname);
 
   int GetNumTimers();
   PVR_ERROR RequestTimerList(PVRHANDLE handle);

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -482,6 +482,14 @@ PVR_ERROR AddTimer(const PVR_TIMERINFO &timerinfo)
   return HTSPData->AddTimer(timerinfo);
 }
 
+PVR_ERROR UpdateTimer(const PVR_TIMERINFO &timerinfo) 
+{ 
+  if(!HTSPData)
+    return PVR_ERROR_SERVER_ERROR;
+
+  return HTSPData->UpdateTimer(timerinfo);
+}
+
 /** UNUSED API FUNCTIONS */
 PVR_ERROR DialogChannelScan() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR MenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -499,7 +507,6 @@ PVR_ERROR AddCutMark(const PVR_CUT_MARK &cutmark) { return PVR_ERROR_NOT_IMPLEME
 PVR_ERROR DeleteCutMark(const PVR_CUT_MARK &cutmark) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR StartCut() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameTimer(const PVR_TIMERINFO &timerinfo, const char *newname) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR UpdateTimer(const PVR_TIMERINFO &timerinfo) { return PVR_ERROR_NOT_IMPLEMENTED; }
 bool SwapLiveTVSecondaryStream() { return false; }
 bool OpenSecondaryStream(const PVR_CHANNEL &channelinfo) { return false; }
 void CloseSecondaryStream() {}

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -490,6 +490,15 @@ PVR_ERROR UpdateTimer(const PVR_TIMERINFO &timerinfo)
   return HTSPData->UpdateTimer(timerinfo);
 }
 
+_ERROR RenameTimer(const PVR_TIMERINFO &timerinfo, const char *newname) 
+{ 
+  if(!HTSPData)
+    return PVR_ERROR_SERVER_ERROR;
+
+  // The new name is already in the timerinfo.title, so we don't need it. Call UpdateTimer instead
+  return HTSPData->UpdateTimer(timerinfo);
+}
+
 /** UNUSED API FUNCTIONS */
 PVR_ERROR DialogChannelScan() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR MenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -506,7 +515,6 @@ PVR_ERROR RequestCutMarksList(PVRHANDLE handle) { return PVR_ERROR_NOT_IMPLEMENT
 PVR_ERROR AddCutMark(const PVR_CUT_MARK &cutmark) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteCutMark(const PVR_CUT_MARK &cutmark) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR StartCut() { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR RenameTimer(const PVR_TIMERINFO &timerinfo, const char *newname) { return PVR_ERROR_NOT_IMPLEMENTED; }
 bool SwapLiveTVSecondaryStream() { return false; }
 bool OpenSecondaryStream(const PVR_CHANNEL &channelinfo) { return false; }
 void CloseSecondaryStream() {}

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -490,13 +490,21 @@ PVR_ERROR UpdateTimer(const PVR_TIMERINFO &timerinfo)
   return HTSPData->UpdateTimer(timerinfo);
 }
 
-_ERROR RenameTimer(const PVR_TIMERINFO &timerinfo, const char *newname) 
+PVR_ERROR RenameTimer(const PVR_TIMERINFO &timerinfo, const char *newname) 
 { 
   if(!HTSPData)
     return PVR_ERROR_SERVER_ERROR;
 
-  // The new name is already in the timerinfo.title, so we don't need it. Call UpdateTimer instead
+  // The new name is already in the timerinfo.title, so we don't need it
   return HTSPData->UpdateTimer(timerinfo);
+}
+
+PVR_ERROR RenameRecording(const PVR_RECORDINGINFO &recinfo, const char *newname) 
+{ 
+  if(!HTSPData)
+    return PVR_ERROR_SERVER_ERROR;
+
+  return HTSPData->RenameRecording(recinfo, newname);
 }
 
 /** UNUSED API FUNCTIONS */
@@ -509,7 +517,6 @@ PVR_ERROR RenameChannel(unsigned int number, const char *newname) { return PVR_E
 PVR_ERROR MoveChannel(unsigned int number, unsigned int newnumber) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DialogChannelSettings(const PVR_CHANNEL &channelinfo) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DialogAddChannel(const PVR_CHANNEL &channelinfo) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR RenameRecording(const PVR_RECORDINGINFO &recinfo, const char *newname) { return PVR_ERROR_NOT_IMPLEMENTED; }
 bool HaveCutmarks() { return false; }
 PVR_ERROR RequestCutMarksList(PVRHANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddCutMark(const PVR_CUT_MARK &cutmark) { return PVR_ERROR_NOT_IMPLEMENTED; }


### PR DESCRIPTION
Of course the client needs patching, too:

https://github.com/jdembski/tvheadend/commit/5482182c80111c6da29628aff0d3007cd0054d2e

I hope the indentation etc. is OK so you don't have too much work pulling this request...
