### PR TITLE
vdr-plugin-vnsiserver atsc / hdpvr patches

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -266,7 +266,8 @@ cResponsePacket* cVNSISession::ReadMessage(int timeout)
 
   cResponsePacket* vresp = NULL;
 
-  bool readSuccess = readData((uint8_t*)&channelID, sizeof(uint32_t), timeout) > 0;  // 2s timeout atm
+  bool readSuccess = readData((uint8_t*)&channelID, sizeof(uint32_t), timeout*5) > 0;  // 10s timeout 
+atm
   if (!readSuccess)
     return NULL;
 

--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -266,8 +266,7 @@ cResponsePacket* cVNSISession::ReadMessage(int timeout)
 
   cResponsePacket* vresp = NULL;
 
-  bool readSuccess = readData((uint8_t*)&channelID, sizeof(uint32_t), timeout*5) > 0;  // 10s timeout 
-atm
+  bool readSuccess = readData((uint8_t*)&channelID, sizeof(uint32_t), timeout*5) > 0;  // 10s timeout atm
   if (!readSuccess)
     return NULL;
 

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/demuxer.h
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/demuxer.h
@@ -31,6 +31,7 @@
 #define PRIVATE_STREAM1   0xBD
 #define PADDING_STREAM    0xBE
 #define PRIVATE_STREAM2   0xBF
+#define PRIVATE_STREAM3   0xFD
 #define AUDIO_STREAM_S    0xC0      /* 1100 0000 */
 #define AUDIO_STREAM_E    0xDF      /* 1101 1111 */
 #define VIDEO_STREAM_S    0xE0      /* 1110 0000 */
@@ -69,7 +70,7 @@ inline bool PesIsMPEGAudioPacket(const uchar *p)
 
 inline bool PesIsPS1Packet(const uchar *p)
 {
-  return ((p)[3] == PRIVATE_STREAM1);
+  return ((p)[3] == PRIVATE_STREAM1 || (p)[3] == PRIVATE_STREAM3 );
 }
 
 inline bool PesIsPaddingPacket(const uchar *p)

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
@@ -171,6 +171,7 @@ int cLivePatFilter::GetPid(SI::PMT::Stream& stream, eStreamType *type, char *lan
   {
     case 0x01: // ISO/IEC 11172 Video
     case 0x02: // ISO/IEC 13818-2 Video
+    case 0x80: // ATSC Video MPEG2 (DigiCypher?)
       LOGCONSOLE("cStreamdevPatFilter PMT scanner adding PID %d (%s)\n", stream.getPid(), psStreamTypes[stream.getStreamType()]);
       *type = stMPEG2VIDEO;
       return stream.getPid();
@@ -276,7 +277,7 @@ int cLivePatFilter::GetPid(SI::PMT::Stream& stream, eStreamType *type, char *lan
        * we check the registration format identifier to see if it
        * holds "AC-3"
        */
-      if (stream.getStreamType() >= 0x80)
+      if (stream.getStreamType() >= 0x81)
       {
         bool found = false;
         for (SI::Loop::Iterator it; (d = stream.streamDescriptors.getNext(it)); )


### PR DESCRIPTION
These patches allow the Hauppauge HDPVR to present 5.1 audio pass through to XBMC when coming from a Cable Box (the audio is passed through, so comes as an ATSC 5.1 stream).
