### PR TITLE
Untitled

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -266,7 +266,7 @@ cResponsePacket* cVNSISession::ReadMessage(int timeout)
 
   cResponsePacket* vresp = NULL;
 
-  bool readSuccess = readData((uint8_t*)&channelID, sizeof(uint32_t), timeout) > 0;  // 2s timeout atm
+  bool readSuccess = readData((uint8_t*)&channelID, sizeof(uint32_t), timeout*5) > 0;  // 10s timeout atm
   if (!readSuccess)
     return NULL;
 

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/demuxer.h
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/demuxer.h
@@ -31,6 +31,7 @@
 #define PRIVATE_STREAM1   0xBD
 #define PADDING_STREAM    0xBE
 #define PRIVATE_STREAM2   0xBF
+#define PRIVATE_STREAM3   0xFD
 #define AUDIO_STREAM_S    0xC0      /* 1100 0000 */
 #define AUDIO_STREAM_E    0xDF      /* 1101 1111 */
 #define VIDEO_STREAM_S    0xE0      /* 1110 0000 */
@@ -69,7 +70,7 @@ inline bool PesIsMPEGAudioPacket(const uchar *p)
 
 inline bool PesIsPS1Packet(const uchar *p)
 {
-  return ((p)[3] == PRIVATE_STREAM1);
+  return ((p)[3] == PRIVATE_STREAM1 || (p)[3] == PRIVATE_STREAM3 );
 }
 
 inline bool PesIsPaddingPacket(const uchar *p)

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
@@ -179,6 +179,7 @@ int cLivePatFilter::GetPid(SI::PMT::Stream& stream, eStreamType *type, char *lan
   {
     case 0x01: // ISO/IEC 11172 Video
     case 0x02: // ISO/IEC 13818-2 Video
+    case 0x80: // ATSC Video MPEG2 (DigiCipher/ATSC-Qam)
       LOGCONSOLE("cStreamdevPatFilter PMT scanner adding PID %d (%s)\n", stream.getPid(), psStreamTypes[stream.getStreamType()]);
       *type = stMPEG2VIDEO;
       return stream.getPid();
@@ -280,11 +281,11 @@ int cLivePatFilter::GetPid(SI::PMT::Stream& stream, eStreamType *type, char *lan
       break;
     default:
       /* This following section handles all the cases where the audio track
-       * info is stored in PMT user info with stream id >= 0x80
+       * info is stored in PMT user info with stream id >= 0x81
        * we check the registration format identifier to see if it
        * holds "AC-3"
        */
-      if (stream.getStreamType() >= 0x80)
+      if (stream.getStreamType() >= 0x81)
       {
         bool found = false;
         for (SI::Loop::Iterator it; (d = stream.streamDescriptors.getNext(it)); )


### PR DESCRIPTION
Patch to allow:        ATSC Video Type of 0x80 (Digicypher)
                             ATSC AC-3 Passthrough audio from Cable Box via Hauppauge HDPVR/pvrinput plugin
                             Increase timeout on channel select to 10 seconds (needed buffering on HDPVR)
