### PR TITLE
FIX: prevent m_curDTS/m_curPTS from set to be zero

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/demuxer.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/demuxer.c
@@ -154,9 +154,13 @@ int cParser::ParsePESHeader(uint8_t *buf, size_t len)
   int64_t dts = PesGetDTS(buf, len);
   if (dts == DVD_NOPTS_VALUE)
     dts = pts;
-
-  m_curDTS = dts & PTS_MASK;
-  m_curPTS = pts & PTS_MASK;
+  
+  dts = dts & PTS_MASK;
+  pts = pts & PTS_MASK;
+  
+  if(pts != 0) m_curDTS = dts;
+  if(dts != 0) m_curPTS = pts;
+  
   return hdr_len;
 }
 


### PR DESCRIPTION
Preventing m_curDTS/m_curPTS from set to be zero.

This prevents gaps/jumps in DTS/PTS-Values. See http://forum.xbmc.org/showthread.php?t=92769
