### PR TITLE
pvr/epg: drop unneeded Load at a time m_bIgnoreDbForClient is not initialized

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3555,7 +3555,10 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 
     OutputDebugString("new file set audiostream:0\n");
     // Switch to default options
-    g_settings.m_currentVideoSettings = g_settings.m_defaultVideoSettings;
+    // PVR channel settings are stored later
+    // default settings would overwrite changed settings for pvr channels
+    if (!item.IsPVR())
+      g_settings.m_currentVideoSettings = g_settings.m_defaultVideoSettings;
     // see if we have saved options in the database
 
     m_iPlaySpeed = 1;
@@ -5333,7 +5336,8 @@ bool CApplication::ProcessAndStartPlaylist(const CStdString& strPlayList, CPlayL
 
 void CApplication::SaveCurrentFileSettings()
 {
-  if (m_itemCurrentFile->IsVideo())
+  // don't store settings for PVR in video database
+  if (m_itemCurrentFile->IsVideo() && !m_itemCurrentFile->IsPVR())
   {
     // save video settings
     if (g_settings.m_currentVideoSettings != g_settings.m_defaultVideoSettings)

--- a/xbmc/pvr/PVREpgContainer.cpp
+++ b/xbmc/pvr/PVREpgContainer.cpp
@@ -38,14 +38,6 @@ void CPVREpgContainer::Clear(bool bClearDb /* = false */)
   CEpgContainer::Clear(bClearDb);
 }
 
-void CPVREpgContainer::Start()
-{
-  /* make sure the EPG is loaded before starting the thread */
-  Load(true /* show progress */);
-
-  CEpgContainer::Start();
-}
-
 bool CPVREpgContainer::CreateChannelEpgs(void)
 {
   for (int radio = 0; radio <= 1; radio++)

--- a/xbmc/pvr/PVREpgContainer.h
+++ b/xbmc/pvr/PVREpgContainer.h
@@ -65,11 +65,6 @@ private:
 
 public:
   /*!
-   * @brief Start the EPG update thread.
-   */
-  void Start();
-
-  /*!
    * @brief Clear all EPG entries.
    * @param bClearDb Clear the database too if true.
    */

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -27,7 +27,8 @@ bool CSaveFileStateJob::DoWork()
 
   if (progressTrackingFile != "")
   {
-    if (m_item.IsVideo())
+	// do not store PVR settings in video database
+    if (m_item.IsVideo() && !m_item.IsPVR())
     {
       CLog::Log(LOGDEBUG, "%s - Saving file state for video item %s", __FUNCTION__, progressTrackingFile.c_str());
 


### PR DESCRIPTION
the Start() method does not add anything to the parent class. Load() is called by the parents' Start(). If Load() is called here some attributes are not initialized.
