### PR TITLE
wrong empty ac3 tracks in vdr-vnsi

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
@@ -317,7 +317,7 @@ int cLivePatFilter::GetPid(SI::PMT::Stream& stream, eStreamType *type, char *lan
         }
         if (!found)
         {
-          LOGCONSOLE("NOT adding PID %d (type 0x%x) RegDesc not found -> UNKOWN\n", stream.getPid(), stream.getStreamType());
+          LOGCONSOLE("NOT adding PID %d (type 0x%x) RegDesc not found -> UNKNOWN\n", stream.getPid(), stream.getStreamType());
         }
       }
       LOGCONSOLE("cStreamdevPatFilter PMT scanner: NOT adding PID %d (%s) %s\n", stream.getPid(), psStreamTypes[stream.getStreamType()<0x1c?stream.getStreamType():0], "UNKNOWN");

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
@@ -317,9 +317,7 @@ int cLivePatFilter::GetPid(SI::PMT::Stream& stream, eStreamType *type, char *lan
         }
         if (!found)
         {
-          LOGCONSOLE("Adding pid %d (type 0x%x) RegDesc not found -> assume AC-3\n", stream.getPid(), stream.getStreamType());
-          *type = stAC3;
-          return stream.getPid();
+          LOGCONSOLE("NOT adding PID %d (type 0x%x) RegDesc not found -> UNKOWN\n", stream.getPid(), stream.getStreamType());
         }
       }
       LOGCONSOLE("cStreamdevPatFilter PMT scanner: NOT adding PID %d (%s) %s\n", stream.getPid(), psStreamTypes[stream.getStreamType()<0x1c?stream.getStreamType():0], "UNKNOWN");


### PR DESCRIPTION
This solve the multiple fake ac3 tracks identified on some channels when some PID without descriptor where identified as AC3 tracks.
