### PR TITLE
Pvr: reset video settings to default

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -363,6 +363,22 @@ bool CPVRDatabase::DeleteChannelSettings()
   return DeleteValues("channelsettings");
 }
 
+bool CPVRDatabase::DeleteChannelSettings(const CPVRChannel &channel)
+{
+  bool bReturn = false;
+
+  /* invalid channel */
+  if (channel.ChannelID() <= 0)
+  {
+	CLog::Log(LOGERROR, "PVRDB - %s - invalid channel id: %i",
+		__FUNCTION__, channel.ChannelID());
+	return bReturn;
+  }
+  CStdString strWhereClause;
+    strWhereClause = FormatSQL("idChannel = %u", channel.ChannelID());
+  return DeleteValues("channelsettings", strWhereClause);
+}
+
 bool CPVRDatabase::GetChannelSettings(const CPVRChannel &channel, CVideoSettings &settings)
 {
   bool bReturn = false;

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -123,6 +123,12 @@ public:
   bool DeleteChannelSettings();
 
   /*!
+   * @brief Remove channel settings from the database.
+   * @return True if channel were removed successfully, false if not.
+   */
+  bool DeleteChannelSettings(const CPVRChannel &channel);
+
+  /*!
    * @brief Get the channel settings from the database.
    * @param channel The channel to get the settings for.
    * @param settings Store the settings in here.

--- a/xbmc/pvr/PVREpgContainer.cpp
+++ b/xbmc/pvr/PVREpgContainer.cpp
@@ -38,14 +38,6 @@ void CPVREpgContainer::Clear(bool bClearDb /* = false */)
   CEpgContainer::Clear(bClearDb);
 }
 
-void CPVREpgContainer::Start()
-{
-  /* make sure the EPG is loaded before starting the thread */
-  Load(true /* show progress */);
-
-  CEpgContainer::Start();
-}
-
 bool CPVREpgContainer::CreateChannelEpgs(void)
 {
   for (int radio = 0; radio <= 1; radio++)

--- a/xbmc/pvr/PVREpgContainer.h
+++ b/xbmc/pvr/PVREpgContainer.h
@@ -65,11 +65,6 @@ private:
 
 public:
   /*!
-   * @brief Start the EPG update thread.
-   */
-  void Start();
-
-  /*!
    * @brief Clear all EPG entries.
    * @param bClearDb Clear the database too if true.
    */

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1186,6 +1186,14 @@ void CPVRManager::SaveCurrentChannelSettings()
     m_database.PersistChannelSettings(*m_currentPlayingChannel->GetPVRChannelInfoTag(), g_settings.m_currentVideoSettings);
     m_database.Close();
   }
+  else if (m_currentPlayingChannel &&
+      /* delete record which might differ from the default settings */
+      !(g_settings.m_currentVideoSettings != g_settings.m_defaultVideoSettings) &&
+      m_database.Open())
+  {
+    m_database.DeleteChannelSettings(*m_currentPlayingChannel->GetPVRChannelInfoTag());
+    m_database.Close();
+  }
 }
 
 void CPVRManager::LoadCurrentChannelSettings()

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -379,6 +379,10 @@ void CPVRManager::Process()
     /* get recordings from the backend */
     PVRRecordings.Load();
 
+    /* notify window that all channels and epg are loaded */
+    UpdateWindow(TV_WINDOW_CHANNELS_TV);
+    UpdateWindow(TV_WINDOW_CHANNELS_RADIO);
+
     m_bLoaded = true;
   }
 


### PR DESCRIPTION
sorry that f93bec90 is included in this request, i know it's on your agenda. i don't know how to bundle particular commits into a pull request.

7c6dc29f is now with DeleteValues()

another small fix is included. if tv window is set as startup window it needs an update after initial load of channels and epgs.
