### PR TITLE
latest changes

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/VNSIDemux.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSIDemux.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-#define __STDC_CONSTANT_MACROS
 #include <stdint.h>
 #include <limits.h>
 #include <libavcodec/avcodec.h> // For codec id's
@@ -143,30 +142,24 @@ DemuxPacket* cVNSIDemux::Read()
       }
       else if (resp->getOpCodeID() == VDR_STREAM_MUXPKT)
       {
-        void   *bin       = resp->getUserData();
-        size_t  binlen    = resp->getUserDataLength();
+        DemuxPacket* p = (DemuxPacket*)resp->getUserData();
 
-        DemuxPacket* pkt = PVR->AllocateDemuxPacket(binlen);
-
-        memcpy(pkt->pData, bin, binlen);
-
-        pkt->iSize      = binlen;
-        pkt->duration   = (double)resp->getDuration() * DVD_TIME_BASE / 1000000;
-        pkt->dts        = (double)resp->getDTS() * DVD_TIME_BASE / 1000000;
-        pkt->pts        = (double)resp->getPTS() * DVD_TIME_BASE / 1000000;
-        pkt->iStreamId  = -1;
+        p->iSize      = resp->getUserDataLength();
+        p->duration   = (double)resp->getDuration() * DVD_TIME_BASE / 1000000;
+        p->dts        = (double)resp->getDTS() * DVD_TIME_BASE / 1000000;
+        p->pts        = (double)resp->getPTS() * DVD_TIME_BASE / 1000000;
+        p->iStreamId  = -1;
         for(int i = 0; i < m_Streams.nstreams; i++)
         {
           if(m_Streams.stream[i].physid == (int)resp->getStreamID())
           {
-            pkt->iStreamId = i;
-            break;
+                p->iStreamId = i;
+                break;
           }
         }
 
-        free(bin);
         delete resp;
-        return pkt;
+        return p;
       }
     }
 

--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -418,7 +418,6 @@ int cVNSISession::readData(uint8_t* buffer, int totalBytes, int TimeOut)
 {
   int bytesRead = 0;
   int thisRead;
-  int readTries = 0;
   int success;
   fd_set readSet;
   struct timeval timeout;
@@ -452,14 +451,6 @@ int cVNSISession::readData(uint8_t* buffer, int totalBytes, int TimeOut)
     if (bytesRead == totalBytes)
     {
       return 1;
-    }
-    else
-    {
-      if (++readTries == 100)
-      {
-        XBMC->Log(LOG_ERROR, "cVNSISession::readData - Too many reads");
-        // return 0;
-      }
     }
   }
 }

--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.h
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.h
@@ -56,4 +56,18 @@ private:
   int         m_protocol;
   CStdString  m_server;
   CStdString  m_version;
+
+  struct {
+        uint32_t opCodeID;
+        uint32_t streamID;
+        uint32_t duration;
+        int64_t pts;
+        int64_t dts;
+        uint32_t userDataLength;
+  } m_streamPacketHeader;
+
+  struct {
+        uint32_t requestID;
+        uint32_t userDataLength;
+  } m_responsePacketHeader;
 };

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.h
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.h
@@ -79,8 +79,8 @@ private:
     uint32_t opcode;
     uint32_t id;
     uint32_t duration;
-    int64_t dts;
     int64_t pts;
+    int64_t dts;
     uint32_t length;
   } m_streamHeader;
 


### PR DESCRIPTION
- direct copy of DemuxPkt:  
  save one memcpy operation on each streampackage
- fix for DTS / PTS mix-up:  
  yes. this was my fault (thanks FernetMenta for reporting).
- removed warning message:  
  i think this isn't really needed
