### PR TITLE
PVR: Fix crash in Channel manager when no channels are available.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -694,6 +694,11 @@ void CGUIDialogPVRChannelManager::Update()
   Clear();
 
   const CPVRChannelGroup *channels = g_PVRChannelGroups.GetGroupAll(m_bIsRadio);
+
+  // No channels available, nothing to do.
+  if( !channels )
+    return;
+
   for (unsigned int i = 0; i < channels->size(); i++)
   {
     CPVRChannel *channel = channels->at(i);


### PR DESCRIPTION
When no backend is available, a first time user will probably go System settings -> Live TV -> Enable and then try the first available option to see whatever is there, which happens to be the channel manager.
