### PR TITLE
database ResultQuery: only return true if num_rows greater 0

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -190,7 +190,8 @@ bool CDatabase::ResultQuery(const CStdString &strQuery)
 
     CStdString strPreparedQuery = PrepareSQL(strQuery.c_str());
 
-    bReturn = m_pDS->query(strPreparedQuery.c_str());
+    if (m_pDS->query(strPreparedQuery.c_str()) && m_pDS->num_rows() > 0)
+      bReturn = true;
   }
   catch (...)
   {


### PR DESCRIPTION
I noticed that because default video settings were always incorrect.
