### PR TITLE
setting timers from the timeline view + small fixes

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4558,7 +4558,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       }
       else if (pItem->HasEPGInfoTag())
       {
-        const CPVRTimerInfoTag *timer = ((CPVREpgInfoTag *) pItem->GetEPGInfoTag())->Timer();
+        CPVRTimerInfoTag *timer = CPVRManager::GetTimers()->GetMatch(pItem);
         if (timer)
         {
           CDateTime now = CDateTime::GetCurrentDateTime();
@@ -4578,7 +4578,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
     {
       if (pItem->HasEPGInfoTag())
       {
-        const CPVRTimerInfoTag *timer = ((CPVREpgInfoTag *) pItem->GetEPGInfoTag())->Timer();
+        CPVRTimerInfoTag *timer = CPVRManager::GetTimers()->GetMatch(pItem);
         if (timer)
         {
           if (timer->Start() > CDateTime::GetCurrentDateTime() && timer->Active())

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -206,7 +206,7 @@ CPVRRecordingInfoTag *CPVRRecordings::GetByPath(CStdString &path)
   {
     fileName.erase(0,11);
     int iClientID = atoi(fileName.c_str());
-    fileName.erase(0,5);
+    fileName.erase(0,6);
 
     if (fileName.IsEmpty())
       return tag;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -436,3 +436,37 @@ CPVRTimerInfoTag *CPVRTimers::GetMatch(const CPVREpgInfoTag *Epg, int *Match)
   return NULL;
 }
 
+CPVRTimerInfoTag *CPVRTimers::GetMatch(const CEpgInfoTag *Epg)
+{
+  CPVRTimerInfoTag *returnTag = NULL;
+
+   for (unsigned int ptr = 0; ptr < size(); ptr++)
+   {
+     CPVRTimerInfoTag *timer = at(ptr);
+
+     if (!Epg || !Epg->GetTable() || !Epg->GetTable()->Channel())
+       continue;
+
+     const CPVRChannel *channel = Epg->GetTable()->Channel();
+     if (timer->ChannelNumber() != channel->ChannelNumber()
+         || timer->IsRadio() != channel->IsRadio())
+       continue;
+
+     if (timer->Start() > Epg->Start() || timer->Stop() < Epg->End())
+       continue;
+
+     returnTag = timer;
+     break;
+   }
+   return returnTag;
+}
+
+CPVRTimerInfoTag *CPVRTimers::GetMatch(const CFileItem *item)
+{
+  CPVRTimerInfoTag *returnTag = NULL;
+
+  if (item && item->HasEPGInfoTag())
+    returnTag = GetMatch(item->GetEPGInfoTag());
+
+  return returnTag;
+}

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -159,4 +159,6 @@ public:
   CPVRTimerInfoTag *GetMatch(CDateTime t);
   CPVRTimerInfoTag *GetMatch(time_t t);
   CPVRTimerInfoTag *GetMatch(const CPVREpgInfoTag *Epg, int *Match = NULL);
+  CPVRTimerInfoTag *GetMatch(const CEpgInfoTag *Epg);
+  CPVRTimerInfoTag *GetMatch(const CFileItem *item);
 };

--- a/xbmc/pvr/windows/GUIWindowPVR.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVR.cpp
@@ -876,7 +876,8 @@ void CGUIWindowPVR::GetContextButtons(int itemNumber, CContextButtons &buttons)
   {
     if (pItem->GetEPGInfoTag()->End() > CDateTime::GetCurrentDateTime())
     {
-      if (((CPVREpgInfoTag *) pItem->GetEPGInfoTag())->Timer() == NULL)
+      CPVRTimerInfoTag *timer = CPVRManager::GetTimers()->GetMatch(pItem->GetEPGInfoTag());
+      if (!timer)
       {
         if (pItem->GetEPGInfoTag()->Start() < CDateTime::GetCurrentDateTime())
         {
@@ -1310,7 +1311,8 @@ bool CGUIWindowPVR::OnContextButtonStartRecord(CFileItem *item, CONTEXT_BUTTON b
       if (iChannel <= 0)
         return bReturn;
 
-      if (tag->Timer())
+      CPVRTimerInfoTag *timer = CPVRManager::GetTimers()->GetMatch(item);
+      if (timer)
       {
         CGUIDialogOK::ShowAndGetInput(19033,19034,0,0);
         return bReturn;
@@ -1351,10 +1353,11 @@ bool CGUIWindowPVR::OnContextButtonStopRecord(CFileItem *item, CONTEXT_BUTTON bu
       CPVREpgInfoTag *tag = (CPVREpgInfoTag *) item->GetEPGInfoTag();
       int iChannel = tag->ChannelTag()->ChannelNumber();
 
-      if (iChannel <= 0 || tag->Timer() == NULL || tag->Timer()->IsRepeating())
+      CPVRTimerInfoTag *timer = CPVRManager::GetTimers()->GetMatch(item);
+      if (iChannel <= 0 || !timer || timer->IsRepeating())
         return bReturn;
 
-      if (CPVRManager::GetTimers()->DeleteTimer(*tag->Timer()))
+      if (CPVRManager::GetTimers()->DeleteTimer(*timer))
         CPVRManager::GetTimers()->Update();
     }
 

--- a/xbmc/pvr/windows/GUIWindowPVR.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVR.cpp
@@ -1868,6 +1868,9 @@ void CGUIWindowPVR::UpdateChannels(bool bRadio)
   m_viewControl.SetCurrentView(bRadio ? CONTROL_LIST_CHANNELS_RADIO : CONTROL_LIST_CHANNELS_TV);
   const CPVRChannelGroup *currentGroup = SelectedGroup(bRadio);
 
+  if (!currentGroup)
+    return;
+
   m_vecItems->m_strPath.Format("pvr://channels/%s/%s/",
       bRadio ? "radio" : "tv",
       m_bShowHiddenChannels ? ".hidden" : currentGroup->GroupName());


### PR DESCRIPTION
there are many possible solutions for this. this is based on my assumptions of the desired design:
- linking timer and epg tags back and forth is nor desired any more, FileItems are copies anyway, so a direct link wouldn't help in this case
- i found those skeletons of PVRTimers::GetMatch -> these should be used?
