### PR TITLE
vdr-vnsi: fix SwitchChannel

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -357,18 +357,19 @@ cResponsePacket* cVNSISession::ReadResult(cRequestPacket* vrp, bool sequence)
   if(!SendMessage(vrp))
     return NULL;
 
-  cResponsePacket *pkt = ReadMessage();
+  cResponsePacket *pkt = NULL;
 
-  if (!pkt)
-    return NULL;
-
-  /* Discard everything other as response packets until it is received */
-  if (pkt->getChannelID() == CHANNEL_REQUEST_RESPONSE || sequence)
+  while((pkt = ReadMessage()))
   {
-    return pkt;
+    /* Discard everything other as response packets until it is received */
+    if (pkt->getChannelID() == CHANNEL_REQUEST_RESPONSE
+        && (!sequence || pkt->getRequestID() == vrp->getSerial()))
+    {
+      return pkt;
+    }
+    else
+      delete pkt;
   }
-
-  delete pkt;
   return NULL;
 }
 


### PR DESCRIPTION
commit SHA: cdc15b63f3bd124903af does more than just removing a useless queue as commented, it changes behavior. this fix restores the original behavior without the queue which fixes channel switching.
