### PR TITLE
Pvr/epg: fix messed up epg data

### DIFF
--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -61,6 +61,7 @@ void CEpgInfoTag::Reset()
   m_iEpisodePart        = 0;
   m_strEpisodeName      = "";
   m_bChanged            = false;
+  m_iUniqueBroadcastID  = -1;
 }
 
 int CEpgInfoTag::GetDuration() const

--- a/xbmc/pvr/epg/PVREpgInfoTag.cpp
+++ b/xbmc/pvr/epg/PVREpgInfoTag.cpp
@@ -101,5 +101,6 @@ void CPVREpgInfoTag::Update(const PVR_PROGINFO &tag)
   SetPlot(tag.description);
   SetGenre(tag.genre_type, tag.genre_sub_type);
   SetParentalRating(tag.parental_rating);
+  SetUniqueBroadcastID(tag.uid);
 //  SetIcon(((CPVREpg *) m_Epg)->Channel()->IconPath());
 }

--- a/xbmc/pvrclients/vdr-vnsi/client.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/client.cpp
@@ -207,7 +207,8 @@ ADDON_STATUS Create(void* hdl, void* props)
     return m_CurStatus;
   }
 
-  VNSIData->EnableStatusInterface(g_bHandleMessages);
+  if (!VNSIData->EnableStatusInterface(g_bHandleMessages))
+    return m_CurStatus;
 
   m_CurStatus = STATUS_OK;
   m_bCreated = true;


### PR DESCRIPTION
please review
after epg update all tags (channel one) were removed by FixOverlappingEvents
- i removed the static key words from the returnTag variables, these caused InfoTag to never return null
- set UniqueBroadcastID when creating a tag
- i think creating a new tag and push it to the container needs a lock as well
- moved Sort() into the bGrabSuccess block of the Update method
