### PR TITLE
epg: only grab new epg tags on update

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -376,6 +376,14 @@ bool CEpg::Update(time_t start, time_t end, int iUpdateTime, bool bStoreInDb /* 
 
   if (bUpdate)
   {
+    /* use time of last epg for update */
+    if (size() > 0)
+    {
+      time_t iLastEpg;
+      at(size()-1)->Start().GetAsTime(iLastEpg);
+      start = start > iLastEpg ? start : iLastEpg;
+    }
+
     m_bInhibitSorting = true;
     bGrabSuccess = UpdateFromScraper(start, end);
     m_bInhibitSorting = false;


### PR DESCRIPTION
i noticed some stutter on epg update while playing a channel. it should be sufficient just to update with new epg?
- starting from start of last epg tag to get little overlapping
- i think it is save outside the lock, there is no other thread which writes to this data
