### PR TITLE
some small fixes

### DIFF
--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -117,7 +117,7 @@ void CEpgContainer::Start(void)
 
   Create();
   SetName("XBMC EPG thread");
-  SetPriority(10);
+  SetPriority(-1);
   CLog::Log(LOGNOTICE, "%s - EPG thread started", __FUNCTION__);
 }
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -177,7 +177,7 @@ bool CPVRManager::TryLoadClients(int iMaxTime /* = 0 */)
         break;
     }
 
-    Sleep(0);
+    Sleep(10);
   }
 
   CLog::Log(LOG_DEBUG, "PVRManager - %s - %s",
@@ -1313,7 +1313,7 @@ void CPVRManager::LoadCurrentChannelSettings()
 {
   if (m_currentPlayingChannel && g_application.m_pPlayer)
   {
-    CVideoSettings loadedChannelSettings;
+    CVideoSettings loadedChannelSettings = g_settings.m_defaultVideoSettings;
 
     /* set the default settings first */
     g_settings.m_currentVideoSettings = g_settings.m_defaultVideoSettings;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -134,7 +134,7 @@ void CPVRManager::Start()
   /* create the supervisor thread to do all background activities */
   Create();
   SetName("XBMC PVRManager");
-  SetPriority(5);
+  SetPriority(-1);
   CLog::Log(LOGNOTICE, "PVRManager - started with %u active clients", m_clients.size());
 }
 

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -94,7 +94,7 @@ bool CPVRRecordings::Update(bool Wait)
   {
     Create();
     SetName("PVR Recordings Update");
-    SetPriority(-5);
+    SetPriority(-1);
   }
   return false;
 }

--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.h
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.h
@@ -40,7 +40,7 @@ public:
   void              Close();
   void              Abort();
 
-  cResponsePacket*  ReadMessage(int timeout = 10);
+  cResponsePacket*  ReadMessage(int timeout = 20);
   bool              SendMessage(cRequestPacket* vrp);
   int               sendData(void* bufR, size_t count);
   int               readData(uint8_t* buffer, int totalBytes, int TimeOut = 2);


### PR DESCRIPTION
1)
calling SetPriority has to follow the Windows implementation, positive values are higher priority. i have implemented SetThreadPriority for linux. i need to do some tests, if you interested in this, i can create another pull request.

2)
GetChannelSettings return true, even if number of rows equals 0. i think this is the intended behavior, so i preloaded the variable with the defaults settings.
There was a Sleep(0) in TryLoadClients which caused my log to get very, very big on error. i changed this to Sleep(10)

3)
slightly increased timeout of vnsi ReadMessage. got errors while experimenting with thread priorities.
