### PR TITLE
linux: SetThreadPriority

### DIFF
--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -185,6 +185,7 @@
 //NOTE: dont try to define __except because it breaks g++ (already uses it).
 
 typedef pthread_t ThreadIdentifier;
+typedef pid_t LwpIdentifier;
 
 struct CXHandle; // forward declaration
 typedef CXHandle* HANDLE;

--- a/xbmc/linux/XHandle.cpp
+++ b/xbmc/linux/XHandle.cpp
@@ -124,6 +124,7 @@ void CXHandle::Init()
   m_nRefCount=1;
   m_tmCreation = time(NULL);
   m_internalLock = SDL_CreateMutex();
+  m_iPriority = 0;
 #ifdef __APPLE__
   m_machThreadPort = 0;
 #endif

--- a/xbmc/linux/XHandle.h
+++ b/xbmc/linux/XHandle.h
@@ -49,6 +49,8 @@ public:
 
   CSemaphore            *m_pSem;
   ThreadIdentifier      m_hThread;
+  LwpIdentifier         m_hLwp;
+  int                   m_iPriority;
   bool                  m_threadValid;
   SDL_cond              *m_hCond;
   std::list<CXHandle*>  m_hParents;

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -50,7 +50,9 @@ static void MakeTlsKeys()
 {
   pthread_key_create(&tlsLocalThread, NULL);
 }
-
+#elif _LINUX
+#include <sys/syscall.h>
+#include "Semaphore.hpp"
 #endif
 
 //////////////////////////////////////////////////////////////////////
@@ -153,6 +155,12 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
 #else
 #ifndef __APPLE__
   pLocalThread = pThread;
+
+  // store LWP id for use in setpriority
+  pThread->m_pSem->Wait();
+  pThread->m_ThreadHandle->m_hLwp = syscall(SYS_gettid);
+  SetThreadPriority(pThread->m_ThreadHandle, pThread->m_ThreadHandle->m_iPriority);
+  delete pThread->m_pSem;
 #endif
   struct sigaction action;
   action.sa_handler = term_handler;
@@ -266,12 +274,21 @@ void CThread::Create(bool bAutoDelete, unsigned stacksize)
   m_bStop = false;
   ::ResetEvent(m_StopEvent);
 
+#ifdef _LINUX
+#ifndef __APPLE__
+  m_pSem = new CSemaphore(0);
+#endif
+#endif
+
   m_ThreadHandle = (HANDLE)_beginthreadex(NULL, stacksize, (PBEGINTHREADEX_THREADFUNC)staticThread, (void*)this, 0, &m_ThreadId);
 
 #ifdef _LINUX
   if (m_ThreadHandle && m_ThreadHandle->m_threadValid && m_bAutoDelete)
     // FIXME: WinAPI can truncate 64bit pthread ids
     pthread_detach(m_ThreadHandle->m_hThread);
+#ifndef __APPLE
+  m_pSem->Post();
+#endif
 #endif
 }
 

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -36,6 +36,8 @@
 #endif
 #include "Event.h"
 
+class CSemaphore;
+
 class IRunnable
 {
 public:
@@ -89,6 +91,7 @@ protected:
 
   volatile bool m_bStop;
   HANDLE m_ThreadHandle;
+  CSemaphore *m_pSem;
 
 private:
   ThreadIdentifier ThreadId() const;


### PR DESCRIPTION
important: please do not pull to your master branch until further testing on different systems

what it does:
linux allows setting nice levels on threads, i don't know about apple, thus this change excludes apple
there is no real mapping of windows priorities to those of linux, this change applies a nice level lower for higher priorities and one nice level higher for lower priorities. (i tried with the windows values, -15 to +2, which resulted in bad behavior)
i noticed just one thread, audio, which claims a higher priority. on systems with appropriate pam settings for the user who starts the application, this higher prio will be applied. if privileges don't allow this, an error will be logged (but application should run normally)

i tested on ubuntu maverick (vdpau) with good results. no stutter watching different content with many epg update cycles.

there might come problems like too short timeouts (threads with lower priorities) to the surface. i already fixed one in vdr-vnsi. 
