### PR TITLE
ARM DLL for addons

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -43,6 +43,8 @@
 #define ADDON_DLL "/library.xbmc.addon/libXBMC_addon-powerpc-linux.so"
 #elif defined(_POWERPC64)
 #define ADDON_DLL "/library.xbmc.addon/libXBMC_addon-powerpc64-linux.so"
+#elif defined(_ARMEL)
+#define ADDON_DLL "/library.xbmc.addon/libXBMC_addon-arm.so"
 #else /* !__x86_64__ && !__powerpc__ */
 #define ADDON_DLL "/library.xbmc.addon/libXBMC_addon-i486-linux.so"
 #endif /* __x86_64__ */

--- a/addons/library.xbmc.pvr/libXBMC_pvr.h
+++ b/addons/library.xbmc.pvr/libXBMC_pvr.h
@@ -44,6 +44,8 @@
 #define PVR_HELPER_DLL "/library.xbmc.pvr/libXBMC_pvr-powerpc-linux.so"
 #elif defined(_POWERPC64)
 #define PVR_HELPER_DLL "/library.xbmc.pvr/libXBMC_pvr-powerpc64-linux.so"
+#elif defined(_ARMEL)
+#define PVR_HELPER_DLL "/library.xbmc.pvr/libXBMC_pvr-arm.so"
 #else /* !__x86_64__ && !__powerpc__ */
 #define PVR_HELPER_DLL "/library.xbmc.pvr/libXBMC_pvr-i486-linux.so"
 #endif /* __x86_64__ */


### PR DESCRIPTION
The define DLL sentences help to loading the right libraries for arm and prevents from an error when loading the addon.
I have tested it in Tegra2 with L4T (Ubuntu jaunty 9.04), XBMC Dharma branch from openkamp repository and some PVR clients.
I supposse it needs to be canged also in libXBMC_gui.h, but I haven't test it because PVR clients don't use it as far as I now.
