### PR TITLE
pvr: make default/global remote key for ParentDir work in pvr window

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -381,7 +381,6 @@
       <green>Green</green>
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
-      <back>PreviousMenu</back>
     </remote>
   </TV>
   <Settings>


### PR DESCRIPTION
with a default remote configuration you have two buttons for previous menu in pvr but none for parent dir. fixes problems with navigation in recordings.
