### PR TITLE
Use the new TvHeadend function when deleting a recording, so that the recording file is actually deleted.

### DIFF
--- a/xbmc/pvrclients/tvheadend/HTSPData.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPData.cpp
@@ -460,11 +460,11 @@ PVR_ERROR cHTSPData::DeleteTimer(const PVR_TIMER &timer, bool bForce)
   XBMC->Log(LOG_DEBUG, "%s", __FUNCTION__);
 
   htsmsg_t *msg = htsmsg_create_map();
-  htsmsg_add_str(msg, "method", "deleteDvrEntry");
+  htsmsg_add_str(msg, "method", "cancelDvrEntry");
   htsmsg_add_u32(msg, "id", timer.iClientIndex);
   if ((msg = ReadResult(msg)) == NULL)
   {
-    XBMC->Log(LOG_DEBUG, "%s - Failed to get deleteDvrEntry", __FUNCTION__);
+    XBMC->Log(LOG_DEBUG, "%s - Failed to get cancelDvrEntry", __FUNCTION__);
     return PVR_ERROR_SERVER_ERROR;
   }
 


### PR DESCRIPTION
Use the new TvHeadend function when deleting a recording, so that the recording file is actually deleted (this should be pulled only after/if andoma pulls this request in tvheadend: 
https://github.com/andoma/tvheadend/pull/27 ).
Actually, I just changed the function that deletes a timer (not a recording) to use the old tvheadend function (which now has a new name). The function that deletes a recording calls the function it called before, which should now stop the recording (if it is running) and delete the file.
I think this should be the proper flow.
