### PR TITLE
pvr: fix for all bugs related to recording updates

### DIFF
--- a/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
+++ b/lib/addons/library.xbmc.pvr/libXBMC_pvr.cpp
@@ -143,7 +143,7 @@ DLLEXPORT void PVR_trigger_recording_update()
   if (m_cb == NULL)
     return;
 
-  m_cb->TriggerTimerUpdate(m_Handle->addonData);
+  m_cb->TriggerRecordingUpdate(m_Handle->addonData);
 }
 
 DLLEXPORT void PVR_free_demux_packet(DemuxPacket* pPacket)

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -689,8 +689,9 @@ int CPVRClients::GetTimers(CPVRTimers *timers)
 {
   int iCurSize = timers->size();
   CLIENTMAP clients;
-  GetActiveClients(&clients);
+  CSingleLock lock(m_critSection);
 
+  GetActiveClients(&clients);
   /* get the timer list from each client */
   CLIENTMAPITR itrClients = clients.begin();
   while (itrClients != clients.end())
@@ -713,8 +714,9 @@ int CPVRClients::GetRecordings(CPVRRecordings *recordings)
 {
   int iCurSize = recordings->size();
   CLIENTMAP clients;
-  GetActiveClients(&clients);
+  CSingleLock lock(m_critSection);
 
+  GetActiveClients(&clients);
   CLIENTMAPITR itr = clients.begin();
   while (itr != clients.end())
   {

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -106,7 +106,6 @@ bool CPVRRecording::Delete(void)
     return false;
   }
 
-  g_PVRManager.TriggerRecordingsUpdate();
   return true;
 }
 
@@ -120,7 +119,6 @@ bool CPVRRecording::Rename(const CStdString &strNewName)
     return false;
   }
 
-  g_PVRManager.TriggerRecordingsUpdate();
   return true;
 }
 

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -186,7 +186,7 @@ void CPVRRecordings::Update(bool bAsyncUpdate /* = false */)
 
 void CPVRRecordings::ExecuteUpdate(void)
 {
-  CLog::Log(LOGDEBUG, "CPVRTimers - %s - updating recordings", __FUNCTION__);
+  CLog::Log(LOGDEBUG, "CPVRRecordings - %s - updating recordings", __FUNCTION__);
   UpdateFromClients();
 
   CSingleLock lock(m_critSection);

--- a/xbmc/pvrclients/tvheadend/HTSPSession.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPSession.cpp
@@ -738,6 +738,9 @@ void cHTSPSession::ParseDVREntryUpdate(htsmsg_t* msg, SRecordings &recordings, b
   recordings[recording.id] = recording;
 
   PVR->TriggerTimerUpdate();
+
+  if (recording.state == ST_RECORDING)
+   PVR->TriggerRecordingUpdate();
 }
 
 void cHTSPSession::ParseDVREntryDelete(htsmsg_t* msg, SRecordings &recordings, bool bNotify /* = false */)
@@ -759,4 +762,5 @@ void cHTSPSession::ParseDVREntryDelete(htsmsg_t* msg, SRecordings &recordings, b
   recordings.erase(id);
 
   PVR->TriggerTimerUpdate();
+  PVR->TriggerRecordingUpdate();
 }


### PR DESCRIPTION
I just went through the code and I think this commit fixes all problems related to the updating of the recordings; the recording now automatically appears on the list once it actually starts and is also properly removed from the list when it is deleted.
I removed the "manual" update after each action, since we get a callback from TvHeadend. Also had to fixes some other stuff and use 2 new locks (and 1-2 cosmetics); it looks ok and works fine (have tested a lot).
Check it out and tell me your opinion
