### PR TITLE
Replace "Now Playing" with "Currently recording" on fullscreen osd

### DIFF
--- a/addons/skin.confluence/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence/720p/VideoFullScreen.xml
@@ -94,11 +94,35 @@
 					<width>910</width>
 					<height>25</height>
 					<align>left</align>
+					<aligny>center</aligny>
 					<font>font13</font>
 					<label>$LOCALIZE[31040]</label>
 					<textcolor>white</textcolor>
 					<shadowcolor>black</shadowcolor>
+					<visible>![VideoPlayer.Content(LiveTV) + Player.Recording]</visible>
 					<animation effect="slide" start="0,0" end="0,25" time="0" condition="!VideoPlayer.Content(Movies) + !VideoPlayer.Content(Episodes) + !VideoPlayer.Content(MusicVideos) + !VideoPlayer.Content(LiveTV)">conditional</animation>
+				</control>
+				<control type="image" id="1">
+					<posy>0</posy>
+					<width>50</width>
+					<height>25</height>
+					<aspectratio align="center" aligny="center">keep</aspectratio>
+					<texture>PVR-IsRecording.png</texture>
+					<visible>VideoPlayer.Content(LiveTV) + Player.Recording</visible>
+				</control>
+				<control type="label" id="1">
+					<description>Heading label</description>
+					<posx>50</posx>
+					<posy>0</posy>
+					<width>860</width>
+					<height>25</height>
+					<align>left</align>
+					<aligny>center</aligny>
+					<font>font13</font>
+					<label>$LOCALIZE[19158]</label>
+					<textcolor>white</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<visible>VideoPlayer.Content(LiveTV) + Player.Recording</visible>
 				</control>
 				<control type="label" id="1">
 					<description>Studio label</description>


### PR DESCRIPTION
Replace "Now Playing" label on fullscreen osd with "Now Recording" (+icon) when recording.
