### PR TITLE
pvr: fix seek for recordings

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3644,12 +3644,6 @@ void CDVDPlayer::UpdatePlayState(double timeout)
     {
       m_State.canrecord = input->CanRecord();
       m_State.recording = input->IsRecording();
-
-      if(input->GetTotalTime() > 0)
-      {
-        m_State.time       = input->GetStartTime();
-        m_State.time_total = input->GetTotalTime();
-      }
     }
 
     m_State.file_position = m_pInputStream->Seek(0, SEEK_CUR);

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -702,7 +702,8 @@ void CPVRGUIInfo::UpdatePlayingTag(void)
   }
   else if (g_PVRClients->GetPlayingRecording(&recording))
   {
-    m_iDuration = recording.GetDuration();
+    m_playingEpgTag = NULL;
+    m_iDuration = recording.GetDuration() * 60 * 1000;
   }
 }
 


### PR DESCRIPTION
there seems to be no need to overwrite total and current playing time for recordings. some other things i was struggling with:
- GetStartTime is misleading. it actually is the current playing time of a live stream and zero for recordings
- recording.GetDuration returns minutes. i am not sure if this is used in other places and didn't want to change it
