### PR TITLE
pvr: fix broken time info for live streams from commit bf9c6134a1ba635dd7

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3644,6 +3644,12 @@ void CDVDPlayer::UpdatePlayState(double timeout)
     {
       m_State.canrecord = input->CanRecord();
       m_State.recording = input->IsRecording();
+
+      if(input->GetTotalTime() > 0 && input->GetStartTime() > 0)
+      {
+        m_State.time       = input->GetStartTime();
+        m_State.time_total = input->GetTotalTime();
+      }
     }
 
     m_State.file_position = m_pInputStream->Seek(0, SEEK_CUR);


### PR DESCRIPTION
pvr: fix broken time info for live streams from commit bf9c6134a1ba635dd7b83df1e1b2276fa260bfec
