### PR TITLE
epg: fix wrong in-memory epg entries due to wrong searching by channel id instead of epg id

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -686,6 +686,7 @@ const CDateTime &CEpg::GetLastDate(void) const
 bool CEpg::Update(const CEpg &epg, bool bUpdateDb /* = false */)
 {
   bool bReturn = true;
+  CSingleLock lock(m_critSection);
 
   m_strName = epg.m_strName;
   m_strScraperName = epg.m_strScraperName;

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -297,6 +297,24 @@ const CPVRChannel *CPVRChannelGroup::GetByChannelID(int iChannelID) const
   return channel;
 }
 
+const CPVRChannel *CPVRChannelGroup::GetByChannelEpgID(int iEpgID) const
+{
+  CPVRChannel *channel = NULL;
+  CSingleLock lock(m_critSection);
+
+  for (unsigned int ptr = 0; ptr < size(); ptr++)
+  {
+    PVRChannelGroupMember groupMember = at(ptr);
+    if (groupMember.channel->EpgID() == iEpgID)
+    {
+      channel = groupMember.channel;
+      break;
+    }
+  }
+
+  return channel;
+}
+
 const CPVRChannel *CPVRChannelGroup::GetByUniqueID(int iUniqueID) const
 {
   CPVRChannel *channel = NULL;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -299,6 +299,13 @@ namespace PVR
     virtual const CPVRChannel *GetByChannelID(int iChannelID) const;
 
     /*!
+     * @brief Get a channel given it's EPG ID.
+     * @param iEpgID The channel EPG ID.
+     * @return The channel or NULL if it wasn't found.
+     */
+    virtual const CPVRChannel *GetByChannelEpgID(int iEpgID) const;
+
+    /*!
      * @brief Get a channel given it's unique ID.
      * @param iUniqueID The unique ID.
      * @return The channel or NULL if it wasn't found.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -134,6 +134,16 @@ const CPVRChannel *CPVRChannelGroupsContainer::GetChannelById(int iChannelId) co
   return channel;
 }
 
+const CPVRChannel *CPVRChannelGroupsContainer::GetChannelByEpgId(int iEpgId) const
+{
+	const CPVRChannel *channel = m_groupsTV->GetGroupAll()->GetByChannelEpgID(iEpgId);
+
+	if (!channel)
+		channel = m_groupsRadio->GetGroupAll()->GetByChannelEpgID(iEpgId);
+
+	return channel;
+}
+
 bool CPVRChannelGroupsContainer::GetGroupsDirectory(const CStdString &strBase, CFileItemList *results, bool bRadio)
 {
   const CPVRChannelGroups *channelGroups = Get(bRadio);

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -132,6 +132,13 @@ namespace PVR
     const CPVRChannel *GetChannelById(int iChannelId) const;
 
     /*!
+     * @brief Get a channel given it's EPG ID.
+     * @param iEpgId The EPG ID of the channel.
+     * @return The channel or NULL if it wasn't found.
+     */
+    const CPVRChannel *GetChannelByEpgId(int iEpgId) const;
+
+    /*!
      * @brief Get the groups list for a directory.
      * @param strBase The directory path.
      * @param results The file list to store the results in.

--- a/xbmc/pvr/epg/PVREpgContainer.cpp
+++ b/xbmc/pvr/epg/PVREpgContainer.cpp
@@ -79,7 +79,7 @@ bool PVR::CPVREpgContainer::AutoCreateTablesHook(void)
 
 CEpg* PVR::CPVREpgContainer::CreateEpg(int iEpgId)
 {
-  CPVRChannel *channel = (CPVRChannel *) g_PVRChannelGroups->GetChannelById(iEpgId);
+  CPVRChannel *channel = (CPVRChannel *) g_PVRChannelGroups->GetChannelByEpgId(iEpgId);
   if (channel)
   {
     return new CPVREpg(channel, false);


### PR DESCRIPTION
After 2 days of banging my head to the wall, I finally found the culprit.
The problem was much deeper than the startup delay and the changed state of epg entries.
 Hopefully, this will fix a lot of epg-related problems, please review asap
