### PR TITLE
pvr: avoid double timer updates; they will be updated async after the backend confirms each action

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -228,10 +228,7 @@ bool CPVRTimerInfoTag::AddToClient(void)
     return false;
   }
   else
-  {
-    g_PVRManager.TriggerTimersUpdate();
     return true;
-  }
 }
 
 bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */)
@@ -260,7 +257,6 @@ bool CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false */)
     m_epgInfo = NULL;
   }
 
-  g_PVRManager.TriggerTimersUpdate();
   return true;
 }
 
@@ -275,10 +271,6 @@ bool CPVRTimerInfoTag::RenameOnClient(const CStdString &strNewName)
 
     DisplayError(error);
     return false;
-  }
-  else
-  {
-    g_PVRManager.TriggerTimersUpdate();
   }
 
   return true;
@@ -372,10 +364,7 @@ bool CPVRTimerInfoTag::UpdateOnClient()
     return false;
   }
   else
-  {
-    g_PVRManager.TriggerTimersUpdate();
     return true;
-  }
 }
 
 void CPVRTimerInfoTag::DisplayError(PVR_ERROR err) const


### PR DESCRIPTION
An update is triggered right after each timer update notification from the backend, which makes those double updates useless
