### PR TITLE
pvr: fix deleting channels

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -466,8 +466,13 @@ bool CPVRDatabase::RemoveChannelsFromGroup(const CPVRChannelGroup &group)
 
 bool CPVRDatabase::RemoveStaleChannelsFromGroup(const CPVRChannelGroup &group)
 {
-  CStdString strWhereClause = FormatSQL("idGroup = %u AND iChannelNumber > %u", group.GroupID(), group.size());
-  return DeleteValues("map_channelgroups_channels", strWhereClause);
+  bool bDelete = false;
+  /* First remove channels that have don't exist in the main channels table */
+  CStdString strWhereClause = FormatSQL("idChannel = (SELECT map_channelgroups_channels.idChannel FROM map_channelgroups_channels LEFT JOIN channels on map_channelgroups_channels.idChannel = channels.idChannel WHERE channels.idChannel IS NULL)");
+  bDelete = DeleteValues("map_channelgroups_channels", strWhereClause);
+
+  strWhereClause = FormatSQL("idGroup = %u AND iChannelNumber > %u", group.GroupID(), group.size());
+  return bDelete && DeleteValues("map_channelgroups_channels", strWhereClause);
 }
 
 bool CPVRDatabase::DeleteChannelGroups(void)

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -529,8 +529,13 @@ bool CPVRChannelGroup::RemoveDeletedChannels(const CPVRChannelGroup &channels)
           __FUNCTION__, m_bRadio ? "radio" : "TV", channel->ChannelName().c_str(), GroupName().c_str());
 
       /* remove this channel from all non-system groups if this is the internal group */
-      if (IsInternalGroup())
+      if (IsInternalGroup()) {
         g_PVRChannelGroups->Get(m_bRadio)->RemoveFromAllGroups(channel);
+        CPVRChannelGroup::RemoveFromGroup(channel);
+
+        /* since it was not found in the internal group, it was deleted from the backend */
+        channel->Delete();
+      }
       else
         RemoveFromGroup(channel);
 

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -313,6 +313,8 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup &chan
       /* if it's present, update the current tag */
       if (existingChannel->UpdateFromClient(*member.channel))
       {
+        existingChannel->Persist(!m_bLoaded);
+
         bReturn = true;
         CLog::Log(LOGINFO,"PVRChannelGroupInternal - %s - updated %s channel '%s'",
             __FUNCTION__, m_bRadio ? "radio" : "TV", member.channel->ChannelName().c_str());


### PR DESCRIPTION
1) My previous speed oriented patch had a bug
2) When a channel was deleted from the backend, it never actually got deleted neither from memory nor from db (internal groups).
