### PR TITLE
pvr: create objects in CPVRFile when opening recordings or live streams, 

### DIFF
--- a/xbmc/filesystem/PVRFile.cpp
+++ b/xbmc/filesystem/PVRFile.cpp
@@ -70,7 +70,8 @@ bool CPVRFile::Open(const CURL& url)
     const CPVRChannel *tag = g_PVRChannelGroups->GetByPath(strURL);
     if (tag)
     {
-      if (!g_PVRManager.OpenLiveStream(*tag))
+      CPVRChannel *newTag = new CPVRChannel(*tag);
+      if (!g_PVRManager.OpenLiveStream(*newTag))
         return false;
 
       m_isPlayRecording = false;
@@ -84,10 +85,11 @@ bool CPVRFile::Open(const CURL& url)
   }
   else if (strURL.Left(17) == "pvr://recordings/")
   {
-    CPVRRecording *tag = g_PVRRecordings->GetByPath(strURL);
+    const CPVRRecording *tag = g_PVRRecordings->GetByPath(strURL);
     if (tag)
     {
-      if (!g_PVRManager.OpenRecordedStream(*tag))
+      CPVRRecording *newTag = new CPVRRecording(*tag);
+      if (!g_PVRManager.OpenRecordedStream(*newTag))
         return false;
 
       m_isPlayRecording = true;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -482,9 +482,15 @@ bool CPVRClients::OpenLiveStream(const CPVRChannel &tag)
   CSingleLock lock(m_critSection);
 
   if (m_currentChannel)
+  {
     delete m_currentChannel;
+    m_currentChannel = NULL;
+  }
   if (m_currentRecording)
+  {
     delete m_currentRecording;
+    m_currentRecording = NULL;
+  }
 
   ResetQualityData();
 
@@ -524,6 +530,8 @@ bool CPVRClients::CloseLiveStream(void)
     bReturn = true;
   }
 
+  delete m_currentChannel;
+  m_currentChannel = NULL;
   return bReturn;
 }
 
@@ -598,9 +606,15 @@ bool CPVRClients::OpenRecordedStream(const CPVRRecording &tag)
   CSingleLock lock(m_critSection);
 
   if (m_currentChannel)
+  {
     delete m_currentChannel;
+    m_currentChannel = NULL;
+  }
   if (m_currentRecording)
+  {
     delete m_currentRecording;
+    m_currentRecording = NULL;
+  }
 
   /* try to open the recording stream on the client */
   if (m_clientMap[tag.m_iClientId]->OpenRecordedStream(tag))
@@ -628,6 +642,8 @@ bool CPVRClients::CloseRecordedStream(void)
     bReturn = true;
   }
 
+  delete m_currentRecording;
+  m_currentRecording = NULL;
   return bReturn;
 }
 


### PR DESCRIPTION
pvr: create objects in CPVRFile when opening recordings or live streams, fixes segfault when starting recordings

every time a recording was stopped, the tag was deleted from the collection. i think the reason this didn't happen for live streams is the const qualifier of the channel tag in CPVRFile.
i think objects/copies are needed in this case bacause the collection might change during playback.
