### PR TITLE
pvr: fix observers notification upon checking epg active tag

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -301,17 +301,20 @@ const CEpgInfoTag *CEpg::InfoTagNext(void) const
   return NULL;
 }
 
-void CEpg::CheckPlayingEvent(void)
+bool CEpg::CheckPlayingEvent(void)
 {
+  bool bChanged(false);
   CSingleLock lock(m_critSection);
   const CEpgInfoTag *currentEvent = m_nowActive;
   const CEpgInfoTag *updatedEvent = InfoTagNow();
 
-  if (!currentEvent || !updatedEvent || *currentEvent != *updatedEvent)
+  if ((!currentEvent && updatedEvent) || (currentEvent && !updatedEvent) || (currentEvent && *currentEvent != *updatedEvent))
   {
     SetChanged();
-    NotifyObservers("epg");
+    NotifyObservers("epg-current-event");
+    bChanged = true;
   }
+  return bChanged;
 }
 
 const CEpgInfoTag *CEpg::GetTag(int uniqueID, const CDateTime &StartTime) const

--- a/xbmc/epg/Epg.h
+++ b/xbmc/epg/Epg.h
@@ -329,7 +329,7 @@ namespace EPG
     /*!
      * @brief Notify observers when the currently active tag changed.
      */
-    virtual void CheckPlayingEvent(void);
+    virtual bool CheckPlayingEvent(void);
 
     /*!
      * @brief Convert a genre id and subid to a human readable name.

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -235,8 +235,9 @@ namespace EPG
 
     /*!
      * @brief Notify EPG table observers when the currently active tag changed.
+     * @return True if the check was done, false if it was not the right time to check
      */
-    virtual void CheckPlayingEvents(void);
+    virtual bool CheckPlayingEvents(void);
 
     /*!
      * @brief Close the progress bar if it's visible.

--- a/xbmc/pvr/epg/PVREpgContainer.cpp
+++ b/xbmc/pvr/epg/PVREpgContainer.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "threads/SingleLock.h"
+#include "settings/AdvancedSettings.h"
 #include "PVREpgContainer.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -218,4 +219,14 @@ bool PVR::CPVREpgContainer::InterruptUpdate(void) const
       (g_guiSettings.GetBool("epg.preventupdateswhileplayingtv") &&
        g_PVRManager.IsStarted() &&
        g_PVRManager.IsPlaying()));
+}
+
+bool CPVREpgContainer::CheckPlayingEvents(void)
+{
+	if (CEpgContainer::CheckPlayingEvents())
+	{
+    m_iLastEpgActiveTagCheck -= m_iLastEpgActiveTagCheck % 60;
+    return true;
+	}
+	return false;
 }

--- a/xbmc/pvr/epg/PVREpgContainer.h
+++ b/xbmc/pvr/epg/PVREpgContainer.h
@@ -109,5 +109,11 @@ namespace PVR
       * @return The end time.
       */
     const CDateTime GetLastEPGDate(bool bRadio = false);
+
+    /*!
+     * @brief Notify EPG table observers when the currently active tag changed.
+     * @return True if the check was done, false if it was not the right time to check
+     */
+    bool CheckPlayingEvents(void);
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -32,6 +32,7 @@
 #include "pvr/windows/GUIWindowPVR.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/timers/PVRTimers.h"
+#include "pvr/epg/PVREpgContainer.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
@@ -54,6 +55,7 @@ CGUIWindowPVRChannels::CGUIWindowPVRChannels(CGUIWindowPVR *parent, bool bRadio)
 void CGUIWindowPVRChannels::ResetObservers(void)
 {
   CSingleLock lock(m_critSection);
+  g_PVREpg->RegisterObserver(this);
   g_PVRTimers->RegisterObserver(this);
 }
 
@@ -127,7 +129,7 @@ void CGUIWindowPVRChannels::SetSelectedGroup(CPVRChannelGroup *group)
 
 void CGUIWindowPVRChannels::Notify(const Observable &obs, const CStdString& msg)
 {
-  if (msg.Equals("channelgroup") || msg.Equals("timers-reset") || msg.Equals("timers"))
+  if (msg.Equals("channelgroup") || msg.Equals("timers-reset") || msg.Equals("timers") || msg.Equals("epg-now"))
   {
     if (IsVisible())
       SetInvalid();
@@ -167,6 +169,7 @@ void CGUIWindowPVRChannels::UpdateData(void)
   m_bIsFocusing = true;
   m_bUpdateRequired = false;
 
+  g_PVREpg->RegisterObserver(this);
   g_PVRTimers->RegisterObserver(this);
 
   /* lock the graphics context while updating */


### PR DESCRIPTION
pvr: fix observers notification upon checking epg active tag (notify once) and have GUIWindowPVRChannels observe those changes, so that it refreshes properly
