### PR TITLE
Fix EPG and PVRManager crashes

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -107,6 +107,9 @@ void CGUIEPGGridContainer::Render()
 
   UpdateScrollOffset();
 
+  if (!m_programmeScrollOffset || !m_channelScrollOffset)
+    return;
+
   int chanOffset  = (int)floorf(m_channelScrollOffset / m_programmeLayout->Size(m_orientation));
   int blockOffset = (int)floorf(m_programmeScrollOffset / m_blockSize);
   int rulerOffset = (int)floorf(m_programmeScrollOffset / m_blockSize);
@@ -1260,6 +1263,9 @@ int CGUIEPGGridContainer::GetItemSize(GridItemsPtr *item)
 
 int CGUIEPGGridContainer::GetBlock(const CGUIListItemPtr &item, const int &channel)
 {
+  if (!item)
+    return 0;
+
   return GetRealBlock(item, channel) - m_blockOffset;
 }
 

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -102,13 +102,10 @@ void CGUIEPGGridContainer::Render()
   if (m_bInvalidated)
     UpdateLayout();
 
-  if (!m_focusedChannelLayout || !m_channelLayout || !m_rulerLayout || !m_focusedProgrammeLayout || !m_programmeLayout || m_rulerItems.empty() || (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0))
+  if (!m_focusedChannelLayout || !m_channelLayout || !m_rulerLayout || !m_focusedProgrammeLayout || !m_programmeLayout || m_rulerItems.size()<=1 || (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0))
     return;
 
   UpdateScrollOffset();
-
-  if (!m_programmeScrollOffset || !m_channelScrollOffset)
-    return;
 
   int chanOffset  = (int)floorf(m_channelScrollOffset / m_programmeLayout->Size(m_orientation));
   int blockOffset = (int)floorf(m_programmeScrollOffset / m_blockSize);
@@ -926,7 +923,7 @@ bool CGUIEPGGridContainer::MoveChannel(bool direction)
 
 bool CGUIEPGGridContainer::MoveProgrammes(bool direction)
 {
-  if (!m_gridIndex)
+  if (!m_gridIndex || !m_item)
     return false;
 
   if (direction)
@@ -1098,15 +1095,21 @@ void CGUIEPGGridContainer::SetChannel(int channel)
   if (m_blockCursor + m_blockOffset == 0 || m_blockOffset + m_blockCursor + GetItemSize(m_item) == m_blocks)
   {
     m_item          = GetItem(channel);
-    m_blockCursor   = GetBlock(m_item->item, channel);
-    m_channelCursor = channel;
+    if (m_item)
+    {
+      m_blockCursor   = GetBlock(m_item->item, channel);
+      m_channelCursor = channel;
+    }
     return;
   }
 
   /* basic checks failed, need to correctly identify nearest item */
   m_item          = GetClosestItem(channel);
-  m_channelCursor = channel;
-  m_blockCursor   = GetBlock(m_item->item, m_channelCursor);
+  if (m_item)
+  {
+    m_channelCursor = channel;
+    m_blockCursor   = GetBlock(m_item->item, m_channelCursor);
+  }
 }
 
 void CGUIEPGGridContainer::SetBlock(int block)
@@ -1226,6 +1229,10 @@ CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset) const
 GridItemsPtr *CGUIEPGGridContainer::GetClosestItem(const int &channel)
 {
   GridItemsPtr *closest = GetItem(channel);
+
+  if(!closest)
+    return NULL;
+
   int block = GetBlock(closest->item, channel);
   int left;   // num blocks to start of previous item
   int right;  // num blocks to start of next item

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -72,9 +72,9 @@ CPVRManager::~CPVRManager(void)
 {
   Stop();
 
+  delete m_timers;
   delete m_epg;
   delete m_recordings;
-  delete m_timers;
   delete m_channelGroups;
   delete m_addons;
   delete m_guiInfo;


### PR DESCRIPTION
Hi Lars,

These patches fix 3 crashes.
Selecting the EPG timeline view without EPG items for any channel causes an out-of-bound access due to missing NULL pointer checks.
The crash in the PVRManager was caused due to accessing already deleted memory (g_PVREpg).

Grt,
Marcel
