### PR TITLE
pvr: save video settings right after they have been changed by user, fixe

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3623,10 +3623,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 
     OutputDebugString("new file set audiostream:0\n");
     // Switch to default options
-    // PVR channel settings are stored later
-    // default settings would overwrite changed settings for pvr channels
-    if (!item.IsPVR())
-      g_settings.m_currentVideoSettings = g_settings.m_defaultVideoSettings;
+    g_settings.m_currentVideoSettings = g_settings.m_defaultVideoSettings;
     // see if we have saved options in the database
 
     m_iPlaySpeed = 1;
@@ -4158,12 +4155,15 @@ bool CApplication::IsPlayingFullScreenVideo() const
 
 void CApplication::SaveFileState()
 {
-  if (!g_settings.GetCurrentProfile().canWriteDatabases())
-    return;
-  CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
-      m_progressTrackingVideoResumeBookmark,
-      m_progressTrackingPlayCountUpdate);
-  CJobManager::GetInstance().AddJob(job, NULL);
+  if (!m_progressTrackingItem->IsPVRChannel())
+  {
+    if (!g_settings.GetCurrentProfile().canWriteDatabases())
+      return;
+    CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
+        m_progressTrackingVideoResumeBookmark,
+        m_progressTrackingPlayCountUpdate);
+    CJobManager::GetInstance().AddJob(job, NULL);
+  }
 }
 
 void CApplication::UpdateFileState()
@@ -5426,7 +5426,7 @@ bool CApplication::ProcessAndStartPlaylist(const CStdString& strPlayList, CPlayL
 void CApplication::SaveCurrentFileSettings()
 {
   // don't store settings for PVR in video database
-  if (m_itemCurrentFile->IsVideo() && !m_itemCurrentFile->IsPVR())
+  if (m_itemCurrentFile->IsVideo() && !m_itemCurrentFile->IsPVRChannel())
   {
     // save video settings
     if (g_settings.m_currentVideoSettings != g_settings.m_defaultVideoSettings)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -284,6 +284,11 @@ namespace PVR
     void TriggerChannelGroupsUpdate(void);
 
     /*!
+     * @brief Let the background thread save the current video settings.
+     */
+    void TriggerSaveChannelSettings(void);
+
+    /*!
      * @brief Update the channel that is currently active.
      * @param item The new channel.
      * @return True if it was updated correctly, false otherwise.
@@ -391,6 +396,11 @@ namespace PVR
      */
     bool IsSelectedGroup(const CPVRChannelGroup &group) const;
 
+    /*!
+     * @brief Persist the current channel settings in the database.
+     */
+    void SaveCurrentChannelSettings(void);
+
   protected:
     /*!
      * @brief PVR update and control thread.
@@ -482,11 +492,6 @@ namespace PVR
     bool StartUpdateThreads(void);
 
     /*!
-     * @brief Persist the current channel settings in the database.
-     */
-    void SaveCurrentChannelSettings(void);
-
-    /*!
      * @brief Load the settings for the current channel from the database.
      */
     void LoadCurrentChannelSettings(void);
@@ -572,6 +577,16 @@ namespace PVR
     CPVRChannelGroupsUpdateJob(void) {}
     virtual ~CPVRChannelGroupsUpdateJob() {}
     virtual const char *GetType() const { return "pvr-update-channelgroups"; }
+
+    virtual bool DoWork();
+  };
+
+  class CPVRChannelSettingsSaveJob : public CJob
+  {
+  public:
+    CPVRChannelSettingsSaveJob(void) {}
+    virtual ~CPVRChannelSettingsSaveJob() {}
+    virtual const char *GetType() const { return "pvr-save-channelsettings"; }
 
     virtual bool DoWork();
   };

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -30,8 +30,7 @@ bool CSaveFileStateJob::DoWork()
 
   if (progressTrackingFile != "")
   {
-	// do not store PVR settings in video database
-    if (m_item.IsVideo() && !m_item.IsPVR())
+    if (m_item.IsVideo())
     {
       CLog::Log(LOGDEBUG, "%s - Saving file state for video item %s", __FUNCTION__, progressTrackingFile.c_str());
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -33,8 +33,10 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "settings/Settings.h"
 #include "addons/Skin.h"
+#include "pvr/PVRManager.h"
 
 using namespace std;
+using namespace PVR;
 
 CGUIDialogVideoSettings::CGUIDialogVideoSettings(void)
     : CGUIDialogSettings(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "VideoOSDSettings.xml")
@@ -213,6 +215,8 @@ void CGUIDialogVideoSettings::OnSettingChanged(SettingInfo &setting)
       g_settings.Save();
     }
   }
+
+  g_PVRManager.TriggerSaveChannelSettings();
 }
 
 CStdString CGUIDialogVideoSettings::FormatInteger(float value, float minimum)


### PR DESCRIPTION
pvr: save video settings right after they have been changed by user, fixes overwrite of channel settings; use video db for recordings

i did some work on channel settings quite a while back which had still some flaws, like opening a video file when playing a pvr channel. i reverted these changes and followed the design pattern of async jobs. i think it's best saving the video settings right after a user has changed them. this way they get stored even if the system crashes for some reason later.
