### PR TITLE
pvr: fix overwriting video settings for channels

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4153,7 +4153,7 @@ bool CApplication::IsPlayingFullScreenVideo() const
 
 void CApplication::SaveFileState()
 {
-  if (!m_progressTrackingItem->IsPVRChannel() || g_settings.GetCurrentProfile().canWriteDatabases())
+  if (m_progressTrackingItem->IsPVRChannel() || !g_settings.GetCurrentProfile().canWriteDatabases())
     return;
   CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
       m_progressTrackingVideoResumeBookmark,
@@ -4234,6 +4234,9 @@ void CApplication::StopPlaying()
     if( m_pKaraokeMgr )
       m_pKaraokeMgr->Stop();
 #endif
+
+    if (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio())
+      g_PVRManager.SaveCurrentChannelSettings();
 
     if (m_pPlayer)
       m_pPlayer->CloseFile();
@@ -5425,6 +5428,10 @@ void CApplication::SaveCurrentFileSettings()
       dbs.SetVideoSettings(m_itemCurrentFile->m_strPath, g_settings.m_currentVideoSettings);
       dbs.Close();
     }
+  }
+  else if (m_itemCurrentFile->IsPVRChannel())
+  {
+    g_PVRManager.SaveCurrentChannelSettings();
   }
 }
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -798,9 +798,6 @@ void CPVRManager::CloseStream(void)
       time_t tNow;
       CDateTime::GetCurrentDateTime().GetAsTime(tNow);
       channel.SetLastWatched(tNow, true);
-
-      /* make sure that channel settings are persisted */
-      SaveCurrentChannelSettings();
     }
   }
 


### PR DESCRIPTION
the following scenarios have to be considered:

1)
open a recording or video while a pvr channel is plying
Application::PlayFile loads new video settings. saving current channel settings in PVRManager::CloseStream is too late. i moved this to Application::SaveCurrentFileSettings, which is called before loading the new settings.

2)
stop a playing channel
SaveCurrentChannelSettings is called from Application::StopPlaying

3)
channel up/down
this case does not interfere with open/close in Apllication.cpp as long as CFileStateJob is not called.

4)
open a pvr channel while playing a pvr channel
same as 1)

Application::SaveFileState - CSaveFileStateJob should never be called for pvr channels.

please review carefully, i messed this up last time
