### PR TITLE
Tvheadend radio support

### DIFF
--- a/xbmc/pvrclients/tvheadend/HTSPConnection.h
+++ b/xbmc/pvrclients/tvheadend/HTSPConnection.h
@@ -49,7 +49,7 @@ public:
   bool        ReadSuccess(htsmsg_t* m, bool sequence = true, std::string action = "");
 
   static bool ParseEvent         (htsmsg_t* msg, uint32_t id, SEvent &event);
-  static void ParseChannelUpdate (htsmsg_t* msg, SChannels &channels);
+  static void ParseChannelUpdate (htsmsg_t* msg, SChannels &channels, STags &tags);
   static void ParseChannelRemove (htsmsg_t* msg, SChannels &channels);
   static void ParseTagUpdate     (htsmsg_t* msg, STags &tags);
   static void ParseTagRemove     (htsmsg_t* msg, STags &tags);

--- a/xbmc/pvrclients/tvheadend/HTSPData.h
+++ b/xbmc/pvrclients/tvheadend/HTSPData.h
@@ -60,7 +60,7 @@ public:
   PVR_ERROR    GetTimers(PVR_HANDLE handle);
   PVR_ERROR    DeleteTimer(const PVR_TIMER &timerinfo, bool force);
   unsigned int GetNumChannelGroups(void);
-  PVR_ERROR    GetChannelGroups(PVR_HANDLE handle);
+  PVR_ERROR    GetChannelGroups(PVR_HANDLE handle, bool bRadio);
   PVR_ERROR    GetChannelGroupMembers(PVR_HANDLE handle, const PVR_CHANNEL_GROUP &group);
 
 protected:
@@ -77,6 +77,7 @@ private:
   SChannels GetChannels();
   SChannels GetChannels(int tag);
   SChannels GetChannels(STag &tag);
+  int GetNumChannels(STag &tag, bool bRadio);
   STags GetTags();
   bool GetEvent(SEvent& event, uint32_t id);
   bool SendEnableAsync();

--- a/xbmc/pvrclients/tvheadend/HTSPTypes.h
+++ b/xbmc/pvrclients/tvheadend/HTSPTypes.h
@@ -86,6 +86,8 @@ struct STag
   std::string      name;
   std::string      icon;
   std::vector<int> channels;
+  bool             radio;
+  bool             hidden;
 
   STag() { Clear(); }
   void Clear()
@@ -94,6 +96,8 @@ struct STag
     name.clear();
     icon.clear();
     channels.clear();
+    radio = false;
+    hidden = false;
   }
   bool BelongsTo(int channel) const
   {

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -477,22 +477,14 @@ int GetChannelGroupsAmount(void)
 
 PVR_ERROR GetChannelGroups(PVR_HANDLE handle, bool bRadio)
 {
-  /* tvheadend doesn't support separated groups, so we only support TV groups */
-  if (bRadio)
-    return PVR_ERROR_NO_ERROR;
-
   if (!HTSPData || !HTSPData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 
-  return HTSPData->GetChannelGroups(handle);
+  return HTSPData->GetChannelGroups(handle, bRadio);
 }
 
 PVR_ERROR GetChannelGroupMembers(PVR_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
-  /* tvheadend doesn't support separated groups, so we only support TV groups */
-  if (group.bIsRadio)
-    return PVR_ERROR_NO_ERROR;
-
   if (!HTSPData || !HTSPData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;
 


### PR DESCRIPTION
As we know tvheadend doesn't support separate radio channels. In my solution, if a channel is tagged 'Radio' or 'radio' in tvheadend, XBMC will recognize it as a radio station. This tag is hidden as it is already implemented as separated feature in XBMC and radio channels don't need to be also in 'Radio' group.

XBMC now also checks, if a tag/group contains any tv or radio channels, and displays the categories only, if they contain any items. That is how we avoid empty radio/tv groups.
