### PR TITLE
[EPG] Store genre string when genreType/genreSubType are not available

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -63,6 +63,10 @@ struct DemuxPacket;
 
 /*! @name PVR entry content event types */
 //@{
+/* These IDs come from the DVB-SI EIT table "content descriptor"
+ * Also known under the name "E-book genre assignments"
+ */
+#define EPG_EVENT_CONTENTMASK_UNDEFINED                0x00
 #define EPG_EVENT_CONTENTMASK_MOVIEDRAMA               0x10
 #define EPG_EVENT_CONTENTMASK_NEWSCURRENTAFFAIRS       0x20
 #define EPG_EVENT_CONTENTMASK_SHOW                     0x30
@@ -76,7 +80,8 @@ struct DemuxPacket;
 #define EPG_EVENT_CONTENTMASK_SPECIAL                  0xB0
 #define EPG_EVENT_CONTENTMASK_USERDEFINED              0xF0
 //@}
-
+/* Set EPGTAG.iGenreType to EPG_GENRE_USE_STRING to transfer genre strings to XBMC */
+#define EPG_GENRE_USE_STRING                          0x100
 
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20
@@ -252,6 +257,7 @@ extern "C" {
     const char *  strIconPath;         /*!< @brief (optional) icon path */
     int           iGenreType;          /*!< @brief (optional) genre type */
     int           iGenreSubType;       /*!< @brief (optional) genre sub type */
+    const char *  strGenreDescription; /*!< @brief (optional) genre. Will be used only when iGenreType = EPG_GENRE_USE_STRING */
     time_t        firstAired;          /*!< @brief (optional) first aired in UTC */
     int           iParentalRating;     /*!< @brief (optional) parental rating */
     int           iStarRating;         /*!< @brief (optional) star rating */

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -23,6 +23,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/VideoSettings.h"
 #include "utils/log.h"
+#include "addons/include/xbmc_pvr_types.h"
 
 #include "EpgDatabase.h"
 #include "EpgContainer.h"
@@ -70,6 +71,7 @@ bool CEpgDatabase::CreateTables(void)
           "iEndTime        integer, "
           "iGenreType      integer, "
           "iGenreSubType   integer, "
+          "sGenre          varchar(128), "
           "iFirstAired     integer, "
           "iParentalRating integer, "
           "iStarRating     integer, "
@@ -110,13 +112,33 @@ bool CEpgDatabase::CreateTables(void)
 
 bool CEpgDatabase::UpdateOldVersion(int iVersion)
 {
-  if (iVersion < GetMinVersion())
+  bool bReturn = true;
+
+  if (iVersion < 4)
   {
-    CLog::Log(LOGERROR, "EpgDB - %s - updating old table versions not supported. please delete '%s'", __FUNCTION__, GetBaseDBName());
+    CLog::Log(LOGERROR, "EpgDB - %s - updating from table versions < 4 not supported. please delete '%s'", __FUNCTION__, GetBaseDBName());
     return false;
   }
 
-  return true;
+  BeginTransaction();
+
+  try
+  {
+    if (iVersion < 5)
+      m_pDS->exec("ALTER TABLE epgtags ADD sGenre varchar(128);");
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "Error attempting to update the database version!");
+    bReturn = false;
+  }
+
+  if (bReturn)
+    CommitTransaction();
+  else
+    RollbackTransaction();
+
+  return bReturn;
 }
 
 bool CEpgDatabase::DeleteEpg(void)
@@ -253,6 +275,7 @@ int CEpgDatabase::Get(CEpg &epg)
         newTag.m_strPlot            = m_pDS->fv("sPlot").get_asString().c_str();
         newTag.m_iGenreType         = m_pDS->fv("iGenreType").get_asInt();
         newTag.m_iGenreSubType      = m_pDS->fv("iGenreSubType").get_asInt();
+        newTag.m_strGenre           = m_pDS->fv("sGenre").get_asString().c_str();
         newTag.m_iParentalRating    = m_pDS->fv("iParentalRating").get_asInt();
         newTag.m_iStarRating        = m_pDS->fv("iStarRating").get_asInt();
         newTag.m_bNotify            = m_pDS->fv("bNotify").get_asBool();
@@ -367,16 +390,19 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
   }
 
   CStdString strQuery;
+  
+  /* Only store the genre string when needed */
+  CStdString strGenre = (tag.GenreType() == EPG_GENRE_USE_STRING) ? tag.Genre() : "";
 
   if (iBroadcastId < 0)
   {
     strQuery = FormatSQL("INSERT INTO epgtags (idEpg, iStartTime, "
-        "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, "
+        "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, sGenre, "
         "iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, %u, %i, %i, %i, %i, %i, %i, '%s', %i);",
+        "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i);",
         iEpgId, iStartTime, iEndTime,
-        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(), tag.GenreType(), tag.GenreSubType(),
+        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         iFirstAired, tag.ParentalRating(), tag.StarRating(), tag.Notify(),
         tag.SeriesNum(), tag.EpisodeNum(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.UniqueBroadcastID());
@@ -384,12 +410,12 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
   else
   {
     strQuery = FormatSQL("REPLACE INTO epgtags (idEpg, iStartTime, "
-        "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, "
+        "iEndTime, sTitle, sPlotOutline, sPlot, iGenreType, iGenreSubType, sGenre, "
         "iFirstAired, iParentalRating, iStarRating, bNotify, iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid, idBroadcast) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i);",
+        "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i);",
         iEpgId, iStartTime, iEndTime,
-        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(), tag.GenreType(), tag.GenreSubType(),
+        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         tag.FirstAiredAsUTC().GetAsDBDateTime().c_str(), tag.ParentalRating(), tag.StarRating(), tag.Notify(),
         tag.SeriesNum(), tag.EpisodeNum(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.UniqueBroadcastID(), iBroadcastId);

--- a/xbmc/epg/EpgDatabase.h
+++ b/xbmc/epg/EpgDatabase.h
@@ -54,7 +54,7 @@ namespace EPG
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetMinVersion(void) const { return 4; };
+    virtual int GetMinVersion(void) const { return 5; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -24,6 +24,7 @@
 #include "EpgContainer.h"
 #include "EpgDatabase.h"
 #include "utils/log.h"
+#include "addons/include/xbmc_pvr_types.h"
 
 using namespace std;
 using namespace EPG;
@@ -240,13 +241,23 @@ void CEpgInfoTag::SetPlot(const CStdString &strPlot)
   }
 }
 
-void CEpgInfoTag::SetGenre(int iID, int iSubID)
+void CEpgInfoTag::SetGenre(int iID, int iSubID, const char* strGenre)
 {
   if (m_iGenreType != iID || m_iGenreSubType != iSubID)
   {
     m_iGenreType    = iID;
     m_iGenreSubType = iSubID;
-    m_strGenre      = CEpg::ConvertGenreIdToString(iID, iSubID);
+    if ((iID == EPG_GENRE_USE_STRING) && (strGenre != NULL) && (strlen(strGenre) > 0))
+    {
+      /* Type and sub type are not given. No EPG color coding possible
+       * Use the provided genre description as backup. */
+      m_strGenre    = strGenre;
+    }
+    else
+    {
+      /* Determine the genre description from the type and subtype IDs */
+      m_strGenre      = CEpg::ConvertGenreIdToString(iID, iSubID);
+    }
     m_bChanged = true;
     UpdatePath();
   }
@@ -384,7 +395,8 @@ bool CEpgInfoTag::Update(const CEpgInfoTag &tag)
       m_iEpisodePart       != tag.m_iEpisodePart ||
       m_iSeriesNumber      != tag.m_iSeriesNumber ||
       m_strEpisodeName     != tag.m_strEpisodeName ||
-      m_iUniqueBroadcastID != tag.m_iUniqueBroadcastID
+      m_iUniqueBroadcastID != tag.m_iUniqueBroadcastID ||
+      ( tag.m_strGenre.length() > 0 && m_strGenre != tag.m_strGenre )
   );
 
   if (bChanged)
@@ -397,7 +409,16 @@ bool CEpgInfoTag::Update(const CEpgInfoTag &tag)
     m_endTime            = tag.m_endTime;
     m_iGenreType         = tag.m_iGenreType;
     m_iGenreSubType      = tag.m_iGenreSubType;
-    m_strGenre           = CEpg::ConvertGenreIdToString(tag.m_iGenreType, tag.m_iGenreSubType);
+    if (m_iGenreType == EPG_GENRE_USE_STRING && tag.m_strGenre.length() > 0)
+    {
+      /* No type/subtype. Use the provided description */
+      m_strGenre         = tag.m_strGenre;
+    }
+    else
+    {
+      /* Determine genre description by type/subtype */
+      m_strGenre         = CEpg::ConvertGenreIdToString(tag.m_iGenreType, tag.m_iGenreSubType);
+    }
     m_firstAired         = tag.m_firstAired;
     m_iParentalRating    = tag.m_iParentalRating;
     m_iStarRating        = tag.m_iStarRating;

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -229,7 +229,7 @@ namespace EPG
      * @param iID The genre type ID.
      * @param iSubID The genre subtype ID.
      */
-    void SetGenre(int iID, int iSubID);
+    void SetGenre(int iID, int iSubID, const char* strGenre);
 
     /*!
      * @brief Get the first air date of this event.

--- a/xbmc/pvr/epg/PVREpgInfoTag.cpp
+++ b/xbmc/pvr/epg/PVREpgInfoTag.cpp
@@ -78,7 +78,7 @@ void PVR::CPVREpgInfoTag::Update(const EPG_TAG &tag)
   SetTitle(tag.strTitle);
   SetPlotOutline(tag.strPlotOutline);
   SetPlot(tag.strPlot);
-  SetGenre(tag.iGenreType, tag.iGenreSubType);
+  SetGenre(tag.iGenreType, tag.iGenreSubType, tag.strGenreDescription);
   SetParentalRating(tag.iParentalRating);
   SetUniqueBroadcastID(tag.iUniqueBroadcastId);
   SetNotify(tag.bNotify);

--- a/xbmc/pvrclients/MediaPortal/epg.cpp
+++ b/xbmc/pvrclients/MediaPortal/epg.cpp
@@ -314,8 +314,8 @@ void cEpg::SetGenre(string& Genre, int genreType, int genreSubType)
       m_genre_type = EPG_EVENT_CONTENTMASK_MUSICBALLETDANCE;
     } else {
       //XBMC->Log(LOG_DEBUG, "epg::setgenre: TODO mapping of MPTV's '%s' genre.", Genre.c_str());
-      m_genre_type     = genreType;
-      m_genre_subtype  = genreSubType;
+      m_genre_type     = EPG_GENRE_USE_STRING;
+      m_genre_subtype  = 0;
     }
   } else {
     m_genre_type = 0;

--- a/xbmc/pvrclients/MediaPortal/pvrclient-mediaportal.cpp
+++ b/xbmc/pvrclients/MediaPortal/pvrclient-mediaportal.cpp
@@ -452,25 +452,25 @@ PVR_ERROR cPVRClientMediaPortal::GetEpg(PVR_HANDLE handle, const PVR_CHANNEL &ch
 
           if (isEnd && epg.StartTime() != 0)
           {
-            broadcast.iUniqueBroadcastId = epg.UniqueId();
-            broadcast.strTitle           = epg.Title();
-            broadcast.iChannelNumber     = channel.iChannelNumber;
-            broadcast.startTime          = epg.StartTime();
-            broadcast.endTime            = epg.EndTime();
-            broadcast.strPlotOutline     = epg.ShortText();
-            broadcast.strPlot            = epg.Description();
-            broadcast.strIconPath        = "";
-            broadcast.iGenreType         = epg.GenreType();
-            broadcast.iGenreSubType      = epg.GenreSubType();
-            //broadcast.genre_text       = epg.Genre();
-            broadcast.firstAired         = epg.OriginalAirDate();
-            broadcast.iParentalRating    = epg.ParentalRating();
-            broadcast.iStarRating        = epg.StarRating();
-            broadcast.bNotify            = false;
-            broadcast.iSeriesNumber      = epg.SeriesNumber();
-            broadcast.iEpisodeNumber     = epg.EpisodeNumber();
-            broadcast.iEpisodePartNumber = atoi(epg.EpisodePart());
-            broadcast.strEpisodeName     = epg.EpisodeName();
+            broadcast.iUniqueBroadcastId  = epg.UniqueId();
+            broadcast.strTitle            = epg.Title();
+            broadcast.iChannelNumber      = channel.iChannelNumber;
+            broadcast.startTime           = epg.StartTime();
+            broadcast.endTime             = epg.EndTime();
+            broadcast.strPlotOutline      = epg.ShortText();
+            broadcast.strPlot             = epg.Description();
+            broadcast.strIconPath         = "";
+            broadcast.iGenreType          = epg.GenreType();
+            broadcast.iGenreSubType       = epg.GenreSubType();
+            broadcast.strGenreDescription = epg.Genre();
+            broadcast.firstAired          = epg.OriginalAirDate();
+            broadcast.iParentalRating     = epg.ParentalRating();
+            broadcast.iStarRating         = epg.StarRating();
+            broadcast.bNotify             = false;
+            broadcast.iSeriesNumber       = epg.SeriesNumber();
+            broadcast.iEpisodeNumber      = epg.EpisodeNumber();
+            broadcast.iEpisodePartNumber  = atoi(epg.EpisodePart());
+            broadcast.strEpisodeName      = epg.EpisodeName();
 
             PVR->TransferEpgEntry(handle, &broadcast);
           }

--- a/xbmc/pvrclients/mythtv/MythXml.cpp
+++ b/xbmc/pvrclients/mythtv/MythXml.cpp
@@ -130,6 +130,7 @@ PVR_ERROR MythXml::requestEPGForChannel(PVR_HANDLE handle, const PVR_CHANNEL &ch
 	  guideItem.strPlot     = epg.description;
 	  guideItem.iGenreType      = epg.genre_type;
 	  guideItem.iGenreSubType  = epg.genre_subtype;
+	  guideItem.strGenreDescription = "";
 	  guideItem.iParentalRating = epg.parental_rating;
 	  guideItem.startTime       = itemStart;
 	  guideItem.endTime         = itemEnd;

--- a/xbmc/pvrclients/tvheadend/HTSPData.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPData.cpp
@@ -225,24 +225,25 @@ PVR_ERROR CHTSPData::GetEpg(PVR_HANDLE handle, const PVR_CHANNEL &channel, time_
         EPG_TAG broadcast;
         memset(&broadcast, 0, sizeof(EPG_TAG));
 
-        broadcast.iUniqueBroadcastId = event.id;
-        broadcast.strTitle           = event.title.c_str();
-        broadcast.iChannelNumber     = event.chan_id >= 0 ? event.chan_id : channel.iUniqueId;
-        broadcast.startTime          = event.start;
-        broadcast.endTime            = event.stop;
-        broadcast.strPlotOutline     = ""; // unused
-        broadcast.strPlot            = event.descs.c_str();
-        broadcast.strIconPath        = ""; // unused
-        broadcast.iGenreType         = (event.content & 0x0F) << 4;
-        broadcast.iGenreSubType      = event.content & 0xF0;
-        broadcast.firstAired         = 0;  // unused
-        broadcast.iParentalRating    = 0;  // unused
-        broadcast.iStarRating        = 0;  // unused
-        broadcast.bNotify            = false;
-        broadcast.iSeriesNumber      = 0;  // unused
-        broadcast.iEpisodeNumber     = 0;  // unused
-        broadcast.iEpisodePartNumber = 0;  // unused
-        broadcast.strEpisodeName     = ""; // unused
+        broadcast.iUniqueBroadcastId  = event.id;
+        broadcast.strTitle            = event.title.c_str();
+        broadcast.iChannelNumber      = event.chan_id >= 0 ? event.chan_id : channel.iUniqueId;
+        broadcast.startTime           = event.start;
+        broadcast.endTime             = event.stop;
+        broadcast.strPlotOutline      = ""; // unused
+        broadcast.strPlot             = event.descs.c_str();
+        broadcast.strIconPath         = ""; // unused
+        broadcast.iGenreType          = (event.content & 0x0F) << 4;
+        broadcast.iGenreSubType       = event.content & 0xF0;
+        broadcast.strGenreDescription = "";
+        broadcast.firstAired          = 0;  // unused
+        broadcast.iParentalRating     = 0;  // unused
+        broadcast.iStarRating         = 0;  // unused
+        broadcast.bNotify             = false;
+        broadcast.iSeriesNumber       = 0;  // unused
+        broadcast.iEpisodeNumber      = 0;  // unused
+        broadcast.iEpisodePartNumber  = 0;  // unused
+        broadcast.strEpisodeName      = ""; // unused
 
         PVR->TransferEpgEntry(handle, &broadcast);
 

--- a/xbmc/pvrclients/vdr-vnsi/VNSIData.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSIData.cpp
@@ -292,17 +292,18 @@ bool cVNSIData::GetEPGForChannel(PVR_HANDLE handle, const PVR_CHANNEL &channel, 
     EPG_TAG tag;
     memset(&tag, 0 , sizeof(tag));
 
-    tag.iChannelNumber     = channel.iChannelNumber;
-    tag.iUniqueBroadcastId = vresp->extract_U32();
-    tag.startTime          = vresp->extract_U32();
-    tag.endTime            = tag.startTime + vresp->extract_U32();
-    uint32_t content       = vresp->extract_U32();
-    tag.iGenreType         = content & 0xF0;
-    tag.iGenreSubType      = content & 0x0F;
-    tag.iParentalRating    = vresp->extract_U32();
-    tag.strTitle           = vresp->extract_String();
-    tag.strPlotOutline     = vresp->extract_String();
-    tag.strPlot            = vresp->extract_String();
+    tag.iChannelNumber      = channel.iChannelNumber;
+    tag.iUniqueBroadcastId  = vresp->extract_U32();
+    tag.startTime           = vresp->extract_U32();
+    tag.endTime             = tag.startTime + vresp->extract_U32();
+    uint32_t content        = vresp->extract_U32();
+    tag.iGenreType          = content & 0xF0;
+    tag.iGenreSubType       = content & 0x0F;
+    tag.strGenreDescription = "";
+    tag.iParentalRating     = vresp->extract_U32();
+    tag.strTitle            = vresp->extract_String();
+    tag.strPlotOutline      = vresp->extract_String();
+    tag.strPlot             = vresp->extract_String();
 
     PVR->TransferEpgEntry(handle, &tag);
     delete[] tag.strTitle;


### PR DESCRIPTION
Allows the usage of genre strings as backup for the iGenreType/iGenreSubType id's.
XBMC still prefers the existing iGenreType/iGenreSubType fields, because this allows for a colored EPG timeline view.
Unfortunately, not all PVR backends and (web) EPG sources can provide these type id's and the translation from all possible genre strings (even in local language) into id's is almost undoable.

This pull request adds the possibility to use genre strings instead. It won't give a colored EPG timeline, but it does show the genre string on the program info dialog.
Only when iGenreType is set to EPG_GENRE_USE_STRING, XBMC will store the provided string in its internal EPG database. For all other genre types, it uses its existing internal type/subtype to string translator.

See also:
http://forum.xbmc.org/showthread.php?t=104155
