### PR TITLE
pvr: set EpgID when creating PVREpg, fixes now and next views when not us

### DIFF
--- a/xbmc/pvr/epg/PVREpg.cpp
+++ b/xbmc/pvr/epg/PVREpg.cpp
@@ -40,6 +40,7 @@ PVR::CPVREpg::CPVREpg(CPVRChannel *channel, bool bLoadedFromDb /* = false */) :
   CEpg(channel->EpgID(), channel->ChannelName(), channel->EPGScraper(), bLoadedFromDb)
 {
   SetChannel(channel);
+  m_iEpgID = channel->ChannelID();
 }
 
 bool PVR::CPVREpg::HasValidEntries(void) const


### PR DESCRIPTION
pvr: set EpgID when creating PVREpg, fixes now and next views when not using database

please review. i am not completely sure if this has any downsides or could be done better.
