### PR TITLE
Problem with the record button

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -446,7 +446,7 @@ CPVRTimerInfoTag *CPVRTimers::InstantTimer(CPVRChannel *channel, bool bStartTime
         newTimer->EndAsLocalTime().GetAsLocalizedTime("", false));
   }
 
-  CDateTime startTime;
+  CDateTime startTime = CDateTime::GetCurrentDateTime().GetAsUTCDateTime();
   newTimer->SetStartFromUTC(startTime);
   newTimer->m_iMarginStart = 0; /* set the start margin to 0 for instant timers */
 


### PR DESCRIPTION
I use XBMC PVR with VDR and VNSI. When I try to record something with the record button, the timer is erased by VDR.
If I watch the timer with the VDR softdevice client, the timer is set to start at 1970/01/01 00:59 !

I think i've found the problem, the start time of the instant timer is not initialized. See the patch.

Regards,

Marc.
