### PR TITLE
re: Update channel settings before starting the stream.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -673,6 +673,7 @@ bool CPVRManager::OpenLiveStream(const CPVRChannel &tag)
     if(m_currentFile)
       delete m_currentFile;
     m_currentFile = new CFileItem(tag);
+    LoadCurrentChannelSettings();
   }
 
   return bReturn;
@@ -848,6 +849,7 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannel &channel, bool bPreview
       CLog::Log(LOGNOTICE, "PVRManager - %s - switched to channel '%s'",
           __FUNCTION__, channel.ChannelName().c_str());
 
+    LoadCurrentChannelSettings();
     m_bIsSwitchingChannels = false;
   }
 


### PR DESCRIPTION
Hi,

Here is a new pull request without c3ca34f.

Hi,

I found something for my problem of video settings being overwritten. (was http://forum.xbmc.org/showthread.php?t=108678).

I'm not sure it's the correct solution but here is what I found.

The video settings are loaded after the cache is filled. The stream is first initialized with the previous settings. When a channel freeze, the new settings are never loaded and when I switch to an other channel, the video settings are saved with the values of the previous channel.

Regards,

Marc.
