### PR TITLE
pvr addons: fix pvr addons being marked as "(blacklisted)" instead of dis

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -198,8 +198,8 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
     AddonPtr addon2;
     if (CAddonMgr::Get().GetAddon(addon->ID(),addon2))
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(305));
-    else if (pItem->GetProperty("Addon.Path").Left(xbmcPath.size()).Equals(xbmcPath))
-      pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24095));
+    else if ((addon->Type() == ADDON_PVRDLL) && (pItem->GetProperty("Addon.Path").Left(xbmcPath.size()).Equals(xbmcPath)))
+      pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24023));
 
     if (!addon->Props().broken.IsEmpty())
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24098));


### PR DESCRIPTION
pvr addons: fix pvr addons being marked as "(blacklisted)" instead of disabled. Fixes #227.
