### PR TITLE
Fix OpenGL Spectrum visualization addon visibility

### DIFF
--- a/addons/visualization.glesspectrum/addon.xml
+++ b/addons/visualization.glesspectrum/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
-  id="visualization.glspectrum"
+  id="visualization.glespectrum"
   version="1.0.0"
   name="GLES Spectrum"
   provider-name="Team XBMC">

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -512,9 +512,12 @@ bool CEpg::UpdateEntries(const CEpg &epg, bool bStoreInDb /* = true */)
   for (unsigned int iTagPtr = 0; iTagPtr < epg.size(); iTagPtr++)
   {
     CEpgInfoTag *newTag = CreateTag();
-    newTag->Update(*epg.at(iTagPtr));
-    newTag->m_Epg = this;
-    push_back(newTag);
+    if (newTag)
+    {
+      newTag->Update(*epg.at(iTagPtr));
+      newTag->m_Epg = this;
+      push_back(newTag);
+    }
   }
 
   /* sort the list */


### PR DESCRIPTION
Fix OpenGL Spectrum visualization addon visibility (glesspectrum had the same id). Fixes #229
