### PR TITLE
Some fixes

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1590,8 +1590,8 @@ bool CDVDPlayer::CheckStartCaching(CCurrentStream& current)
   {
     if (CachePVRStream())
     {
-      if ((current.type == STREAM_AUDIO && m_dvdPlayerAudio.m_messageQueue.GetLevel() == 0) ||
-         (current.type == STREAM_VIDEO && m_dvdPlayerVideo.m_messageQueue.GetLevel() == 0))
+      if ((current.type == STREAM_AUDIO && current.started && m_dvdPlayerAudio.m_messageQueue.GetLevel() == 0) ||
+         (current.type == STREAM_VIDEO && current.started && m_dvdPlayerVideo.m_messageQueue.GetLevel() == 0))
       {
         CLog::Log(LOGDEBUG, "%s stream stalled. start buffering", current.type == STREAM_AUDIO ? "audio" : "video");
         SetCaching(CACHESTATE_PVR);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2401,7 +2401,9 @@ bool CDVDPlayer::HasVideo() const
 {
   if (m_pInputStream)
   {
-    if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || m_CurrentVideo.id >= 0) return true;
+    if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) ||
+        m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) ||
+        m_CurrentVideo.id >= 0) return true;
   }
   return false;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1501,7 +1501,7 @@ void CDVDPlayer::HandlePlaySpeed()
     if (/* if all streams got at least g_advancedSettings.m_iPVRMinCacheLevel in their buffers, we're done */
         ((bGotVideo || bGotAudio) && (!bGotAudio || bAudioLevelOk) && (!bGotVideo || bVideoLevelOk)) ||
         /* or if one of the buffers is full but the stream hasn't been started */
-        (m_CurrentAudio.id >= 0 && m_CurrentVideo.id >= 0 && (bAudioFullNotStarted || bVideoFullNotStarted)))
+        ((bAudioFullNotStarted || bVideoFullNotStarted)))
     {
       CLog::Log(LOGDEBUG, "set caching from pvr to done. audio (%d) = %d. video (%d) = %d",
           bGotAudio, m_dvdPlayerAudio.m_messageQueue.GetLevel(),

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -51,6 +51,7 @@ CPVRClients::CPVRClients(void) :
     m_bChannelScanRunning(false),
     m_bAllClientsConnected(false),
     m_bIsSwitchingChannels(false),
+    m_bIsValidChannelSettings(false),
     m_currentChannel(NULL),
     m_currentRecording(NULL),
     m_scanStart(0),
@@ -549,6 +550,7 @@ bool CPVRClients::SwitchChannel(const CPVRChannel &channel)
       lock.Enter();
       m_currentChannel = &channel;
       ResetQualityData();
+      m_bIsValidChannelSettings = false;
       lock.Leave();
 
       bReturn = true;
@@ -1239,7 +1241,7 @@ void CPVRClients::UpdateCharInfoSignalStatus(void)
 void CPVRClients::SaveCurrentChannelSettings(void)
 {
   CSingleLock lock(m_critSection);
-  if (!m_currentChannel)
+  if (!m_currentChannel || !m_bIsValidChannelSettings)
     return;
 
   CPVRDatabase *database = OpenPVRDatabase();
@@ -1331,5 +1333,8 @@ void CPVRClients::LoadCurrentChannelSettings(void)
     g_application.m_pPlayer->SetDynamicRangeCompression((long)(g_settings.m_currentVideoSettings.m_VolumeAmplification * 100));
     g_application.m_pPlayer->SetSubtitleVisible(g_settings.m_currentVideoSettings.m_SubtitleOn);
     g_application.m_pPlayer->SetSubTitleDelay(g_settings.m_currentVideoSettings.m_SubtitleDelay);
+
+    /* settings can be saved on next channel switch */
+    m_bIsValidChannelSettings = true;
   }
 }

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -649,6 +649,7 @@ namespace PVR
     bool                  m_bChannelScanRunning;      /*!< true when a channel scan is currently running, false otherwise */
     bool                  m_bAllClientsConnected;        /*!< true when all clients are loaded, false otherwise */
     bool                  m_bIsSwitchingChannels;        /*!< true while switching channels */
+    bool                  m_bIsValidChannelSettings;  /*!< true if current channel settings are valid and can be saved */
     const CPVRChannel *   m_currentChannel;           /*!< the channel that is currently playing or NULL if nothing is playing */
     const CPVRRecording * m_currentRecording;         /*!< the recording that is currently playing or NULL if nothing is playing */
     DWORD                 m_scanStart;                /*!< scan start time to check for non present streams */

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -656,7 +656,8 @@ bool CGUIWindowPVRCommon::PlayFile(CFileItem *item, bool bPlayMinimized /* = fal
     bool bSwitchSuccessful(false);
 
     /* try a fast switch */
-    if (item->IsPVRChannel() && (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio()))
+    if (item->IsPVRChannel() && (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio()) &&
+        (item->GetPVRChannelInfoTag()->IsRadio() == g_PVRManager.IsPlayingRadio()))
       bSwitchSuccessful = g_application.m_pPlayer->SwitchChannel(*item->GetPVRChannelInfoTag());
 
     if (!bSwitchSuccessful)


### PR DESCRIPTION
Please review:

1)
aec820c5a654eddba62fe7b648eb74624d641902  pvr: only fastswitch between channels if both are either radio or tv:
addresses #224 and #191

2)
pvr: fix overwriting channel settings after non successful channel switch: 84cd303e65d9db1eb89fe68c4d126048620b5562
addresses #220

3)
pvr: do not show background image or black screen when switching channel: 52af67a03b0288cf1a318012c1e0fd4b23030235
also related to channel switching

4)
10f2a0908227450e3ba2377c44e7ee6783509b52 and b611a16196d6024af3b597d3825c2e85adf4761a address pvr caching

@opdenkamp
If you don't mind and provided that you agree with those changes, I would like trying to submit them myself. But only when you are around, just in case :)
