### PR TITLE
Add teletext support for HTSP protocol

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
@@ -284,6 +284,7 @@ void CDVDDemuxHTSP::SubscriptionStart (htsmsg_t *m)
       CDemuxStreamAudio* a;
       CDemuxStreamVideo* v;
       CDemuxStreamSubtitle* s;
+      CDemuxStreamTeletext* t;
     } st;
 
     CLog::Log(LOGDEBUG, "CDVDDemuxHTSP::SubscriptionStart - id: %d, type: %s", index, type);
@@ -320,6 +321,9 @@ void CDVDDemuxHTSP::SubscriptionStart (htsmsg_t *m)
     } else if(!strcmp(type, "TEXTSUB")) {
       st.s = new CDemuxStreamSubtitle();
       st.s->codec = CODEC_ID_TEXT;
+    } else if(!strcmp(type, "TELETEXT")) {
+      st.t = new CDemuxStreamTeletext();
+      st.t->codec = CODEC_ID_DVB_TELETEXT;
     } else {
       continue;
     }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -801,6 +801,7 @@ bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
     {
       m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
       m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
+      OpenDefaultStreams();
     }
     return true;
   }

--- a/xbmc/pvrclients/tvheadend/HTSPDemux.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPDemux.cpp
@@ -369,11 +369,11 @@ void CHTSPDemux::SubscriptionStart(htsmsg_t *m)
       m_Streams.stream[m_Streams.iStreamCount].iCodecId   = CODEC_ID_TEXT;
       HTSPSetDemuxStreamInfoLanguage(m_Streams.stream[m_Streams.iStreamCount], sub);
     }
-//    else if(!strcmp(type, "TELETEXT"))
-//    {
-//      m_Streams.stream[m_Streams.iStreamCount].iCodecType = AVMEDIA_TYPE_SUBTITLE;
-//      m_Streams.stream[m_Streams.iStreamCount].iCodecId   = CODEC_ID_DVB_TELETEXT;
-//    }
+    else if(!strcmp(type, "TELETEXT"))
+    {
+      m_Streams.stream[m_Streams.iStreamCount].iCodecType = AVMEDIA_TYPE_SUBTITLE;
+      m_Streams.stream[m_Streams.iStreamCount].iCodecId   = CODEC_ID_DVB_TELETEXT;
+    }
     else
     {
       bValidStream = false;


### PR DESCRIPTION
This little addition adds teletext support for HTSP streams.

It works together with this modified tvheadend version:
https://github.com/andoma/tvheadend/pull/44
