### PR TITLE
Fix "undeclared reference to CVariant"

### DIFF
--- a/xbmc/interfaces/json-rpc/SystemOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SystemOperations.cpp
@@ -21,6 +21,7 @@
 
 #include "SystemOperations.h"
 #include "Application.h"
+#include "utils/Variant.h"
 #include "powermanagement/PowerManager.h"
 
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/XBMCOperations.cpp
+++ b/xbmc/interfaces/json-rpc/XBMCOperations.cpp
@@ -23,6 +23,7 @@
 #include "Application.h"
 #include "ApplicationMessenger.h"
 #include "Util.h"
+#include "utils/Variant.h"
 #include "powermanagement/PowerManager.h"
 
 using namespace JSONRPC;


### PR DESCRIPTION
While building xbmc-pvr@master i discovered two errors "undeclared reference to CVariant". This commit fixed them for me.
