### PR TITLE
pvr: fix caching on stalled streams

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1589,7 +1589,7 @@ bool CDVDPlayer::CheckStartCaching(CCurrentStream& current)
          (current.type == STREAM_VIDEO && current.started && m_dvdPlayerVideo.m_messageQueue.GetLevel() == 0))
       {
         CLog::Log(LOGDEBUG, "%s stream stalled. start buffering", current.type == STREAM_AUDIO ? "audio" : "video");
-        SetCaching(CACHESTATE_PVR);
+        SetCaching(CACHESTATE_INIT);
       }
       return true;
     }


### PR DESCRIPTION
Sometimes it happens that the TV livestream stalls. This may happen when the signal on the receiver is lost or the TCP/IP connection to the server is lost.

Currently its impossible to continue streaming when the stream is recovered because there are no more packets requested via DemuxRead. You need to press "Stop" and reselect the channel to start streaming again.

This patch fixes the problem (at least for me).
