### PR TITLE
pvr: fix crashes at XBMC shutdown

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVR.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVR.cpp
@@ -48,15 +48,7 @@ CGUIWindowPVR::CGUIWindowPVR(void) :
 
 CGUIWindowPVR::~CGUIWindowPVR(void)
 {
-  if (m_bViewsCreated)
-  {
-    delete m_windowChannelsRadio;
-    delete m_windowChannelsTV;
-    delete m_windowGuide;
-    delete m_windowRecordings;
-    delete m_windowSearch;
-    delete m_windowTimers;
-  }
+  Cleanup();
 }
 
 CGUIWindowPVRCommon *CGUIWindowPVR::GetActiveView(void) const
@@ -256,6 +248,23 @@ void CGUIWindowPVR::Reset(void)
   CSingleLock graphicsLock(g_graphicsContext);
   CSingleLock lock(m_critSection);
 
+  Cleanup();
+  CreateViews();
+
+  m_windowChannelsRadio->ResetObservers();
+  m_windowChannelsTV->ResetObservers();
+  m_windowGuide->ResetObservers();
+  m_windowRecordings->ResetObservers();
+  m_windowTimers->ResetObservers();
+
+  m_currentSubwindow = NULL;
+  m_savedSubwindow = NULL;
+  ClearFileItems();
+  FreeResources();
+}
+
+void CGUIWindowPVR::Cleanup(void)
+{
   if (m_bViewsCreated)
   {
     m_windowChannelsRadio->UnregisterObservers();
@@ -276,17 +285,4 @@ void CGUIWindowPVR::Reset(void)
     delete m_windowTimers;
     m_bViewsCreated = false;
   }
-
-  CreateViews();
-
-  m_windowChannelsRadio->ResetObservers();
-  m_windowChannelsTV->ResetObservers();
-  m_windowGuide->ResetObservers();
-  m_windowRecordings->ResetObservers();
-  m_windowTimers->ResetObservers();
-
-  m_currentSubwindow = NULL;
-  m_savedSubwindow = NULL;
-  ClearFileItems();
-  FreeResources();
 }

--- a/xbmc/pvr/windows/GUIWindowPVR.h
+++ b/xbmc/pvr/windows/GUIWindowPVR.h
@@ -58,6 +58,7 @@ namespace PVR
     virtual void OnWindowLoaded(void);
     virtual void OnWindowUnload(void);
     virtual void Reset(void);
+    virtual void Cleanup(void);
 
     EPG::CGUIEPGGridContainer *m_guideGrid;
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -66,7 +66,8 @@ void CGUIWindowPVRChannels::UnregisterObservers(void)
 {
   CSingleLock lock(m_critSection);
   g_EpgContainer.UnregisterObserver(this);
-  g_PVRTimers->UnregisterObserver(this);
+  if (g_PVRTimers)
+    g_PVRTimers->UnregisterObserver(this);
   g_infoManager.UnregisterObserver(this);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -44,8 +44,10 @@ CGUIWindowPVRRecordings::CGUIWindowPVRRecordings(CGUIWindowPVR *parent) :
 void CGUIWindowPVRRecordings::UnregisterObservers(void)
 {
   CSingleLock lock(m_critSection);
-  g_PVRRecordings->UnregisterObserver(this);
-  g_PVRTimers->UnregisterObserver(this);
+  if(g_PVRRecordings)
+    g_PVRRecordings->UnregisterObserver(this);
+  if(g_PVRTimers)
+    g_PVRTimers->UnregisterObserver(this);
   g_infoManager.UnregisterObserver(this);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -41,7 +41,8 @@ CGUIWindowPVRTimers::CGUIWindowPVRTimers(CGUIWindowPVR *parent) :
 void CGUIWindowPVRTimers::UnregisterObservers(void)
 {
   CSingleLock lock(m_critSection);
-  g_PVRTimers->UnregisterObserver(this);
+  if (g_PVRTimers)
+    g_PVRTimers->UnregisterObserver(this);
 }
 
 void CGUIWindowPVRTimers::ResetObservers(void)


### PR DESCRIPTION
pvr: fix crash in destructor GUIInfoManager due to missing UnregisterObserver calls.
Add also null pointer checks for g_PVRTimers and g_PVRRecordings because these items are already deleted during the cleanup of GUIWindowPVR.
