### PR TITLE
Issue #273: [FR] store pvr recordings in the video db

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -729,6 +729,7 @@ bool CFileItem::IsVideo() const
   if (HasVideoInfoTag()) return true;
   if (HasMusicInfoTag()) return false;
   if (HasPictureInfoTag()) return false;
+  if (IsPVRRecording())  return true;
 
   if (IsHDHomeRun() || IsTuxBox() || URIUtils::IsDVD(m_strPath) || IsSlingbox())
     return true;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -36,6 +36,8 @@ namespace PVR
     CGUIWindowPVRRecordings(CGUIWindowPVR *parent);
     virtual ~CGUIWindowPVRRecordings(void) {};
 
+    static CStdString GetResumeString(CFileItem item);
+
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) const;
     virtual bool OnAction(const CAction &action);
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
@@ -46,6 +48,7 @@ namespace PVR
     virtual void ResetObservers(void);
 
   private:
+
     virtual bool OnClickButton(CGUIMessage &message);
     virtual bool OnClickList(CGUIMessage &message);
 


### PR DESCRIPTION
Pvr recordings get stored to the video database.
Implemented resume context menus for pvr recordings.
Show resume choice on selecting a recording with resume bookmark.
Recordings are now resumable like other video stuff.
