### PR TITLE
[FR] Add PVR recordings to the library

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -862,6 +862,17 @@ CStdString CDateTime::GetAsDBDateTime() const
   return date;
 }
 
+CStdString CDateTime::GetAsSaveString() const
+{
+  SYSTEMTIME st;
+  GetAsSystemTime(st);
+
+  CStdString date;
+  date.Format("%04i%02i%02i_%02i%02i%02i", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+
+  return date;
+}
+
 void CDateTime::SetFromUTCDateTime(const CDateTime &dateTime)
 {
   TIME_ZONE_INFORMATION tz;

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -183,6 +183,7 @@ public:
   void GetAsTimeStamp(FILETIME& time) const;
 
   CDateTime GetAsUTCDateTime() const;
+  CStdString GetAsSaveString() const;
   CStdString GetAsDBDateTime() const;
   CStdString GetAsDBDate() const;
   CStdString GetAsLocalizedDate(bool longDate=false, bool withShortNames=true) const;

--- a/xbmc/filesystem/PVRFile.cpp
+++ b/xbmc/filesystem/PVRFile.cpp
@@ -294,6 +294,11 @@ bool CPVRFile::Rename(const CURL& url, const CURL& urlnew)
   return false;
 }
 
+bool CPVRFile::Exists(const CURL& url)
+{
+  return g_PVRRecordings->GetByPath(url.Get()) != NULL;
+}
+
 int CPVRFile::IoControl(EIoControl request, void *param)
 {
   if (request == IOCTRL_SEEK_POSSIBLE)

--- a/xbmc/filesystem/PVRFile.h
+++ b/xbmc/filesystem/PVRFile.h
@@ -49,7 +49,7 @@ public:
 
   virtual bool          Delete(const CURL& url);
   virtual bool          Rename(const CURL& url, const CURL& urlnew);
-  virtual bool          Exists(const CURL& url)                        { return false; }
+  virtual bool          Exists(const CURL& url);
 
   virtual ILiveTVInterface* GetLiveTV() {return (ILiveTVInterface*)this;}
 

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -155,20 +155,38 @@ void CPVRRecording::Update(const CPVRRecording &tag)
   m_strChannelName = tag.m_strChannelName;
   m_strGenre       = tag.m_strGenre;
 
+  CStdString strShow;
+  strShow.Format("%s - ", g_localizeStrings.Get(20364).c_str());
+  if (m_strPlotOutline.Left(strShow.size()).Equals(strShow))
+  {
+    CStdString strEpisode = m_strPlotOutline;
+    CStdString strTitle = m_strDirectory;
+    
+    int pos = strTitle.ReverseFind('/');
+    strTitle.erase(0, pos + 1);
+    strEpisode.erase(0, strShow.size());
+    m_strTitle.Format("%s - %s", strTitle.c_str(), strEpisode);
+    pos = strEpisode.Find('-');
+    strEpisode.erase(0, pos + 2);
+    m_strPlotOutline = strEpisode;
+  }
   UpdatePath();
 }
 
 void CPVRRecording::UpdatePath(void)
 {
   CStdString strTitle = m_strTitle;
+  CStdString strDatetime = m_recordingTime.GetAsSaveString();
   strTitle.Replace('/','-');
 
   if (m_strDirectory != "")
-    m_strFileNameAndPath.Format("pvr://recordings/client_%04i/%s/%s.pvr",
-        m_iClientId, m_strDirectory.c_str(), strTitle.c_str());
+    m_strFileNameAndPath.Format("pvr://recordings/%s/%s/%s.pvr",
+        m_strDirectory.c_str(), strDatetime.c_str(), strTitle.c_str());
   else
-    m_strFileNameAndPath.Format("pvr://recordings/client_%04i/%s.pvr",
-        m_iClientId, strTitle.c_str());
+    m_strFileNameAndPath.Format("pvr://recordings/%s/%s.pvr",
+        strDatetime.c_str(), strTitle.c_str());
+  
+  CLog::Log(LOGINFO, "UpdatePath: '%s' [%s]", m_strFileNameAndPath.c_str(), m_strPlotOutline.c_str());
 }
 
 const CDateTime &CPVRRecording::RecordingTimeAsLocalTime(void) const

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -185,8 +185,6 @@ void CPVRRecording::UpdatePath(void)
   else
     m_strFileNameAndPath.Format("pvr://recordings/%s/%s.pvr",
         strDatetime.c_str(), strTitle.c_str());
-  
-  CLog::Log(LOGINFO, "UpdatePath: '%s' [%s]", m_strFileNameAndPath.c_str(), m_strPlotOutline.c_str());
 }
 
 const CDateTime &CPVRRecording::RecordingTimeAsLocalTime(void) const

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -93,7 +93,6 @@ bool CPVRRecordings::IsDirectoryMember(const CStdString &strDirectory, const CSt
 
 void CPVRRecordings::GetContents(const CStdString &strDirectory, CFileItemList *results) const
 {
-  CStdString strPath;
   for (unsigned int iRecordingPtr = 0; iRecordingPtr < size(); iRecordingPtr++)
   {
     CPVRRecording *current = at(iRecordingPtr);
@@ -103,8 +102,7 @@ void CPVRRecordings::GetContents(const CStdString &strDirectory, CFileItemList *
     CFileItemPtr pFileItem(new CFileItem(*current));
     pFileItem->SetLabel2(current->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false));
     pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
-    strPath.Format("pvr://recordings/%05i-%s.pvr", current->m_iClientId, current->m_strRecordingId);
-    pFileItem->SetPath(strPath);
+    pFileItem->SetPath(current->m_strFileNameAndPath);
     results->Add(pFileItem);
   }
 }
@@ -262,23 +260,14 @@ CPVRRecording *CPVRRecordings::GetByPath(const CStdString &path)
 
   if (fileName.Left(11) == "recordings/")
   {
-    // remove "recordings/" from filename
-    fileName.erase(0,11);
-    int iClientID = atoi(fileName.c_str());
-    // remove client id from filename
-    fileName.erase(0,6);
-
     if (fileName.IsEmpty())
       return tag;
-
-    // remove ".pvr" from filename
-    fileName.erase(fileName.end() - 4, fileName.end());
 
     for (unsigned int iRecordingPtr = 0; iRecordingPtr < size(); iRecordingPtr++)
     {
       CPVRRecording *recording = at(iRecordingPtr);
 
-      if (recording->m_iClientId == iClientID && recording->m_strRecordingId.Equals(fileName))
+      if(path.Equals(recording->m_strFileNameAndPath))
       {
         tag = recording;
         break;


### PR DESCRIPTION
I've seen this topic already in some other issues, however I haven't seen it implemented yet. So I built up my own solution, which is of course more or less specialized for my needs and therefore probably not globally applicable. Anyway I would be glad if a solution similar to this one found its way to XBMC-PVR.

I have a set of more than 600 VDR movie and TV show recordings distributed on several external hard drives, which I wanted to add to the library. My VDR filesystem structure looks like that:

<pre><code>+&lt;vdr base&gt;
  +External disk 1
    +Films
      +Film1
      +Film2
      +...
    +TV Shows
      +Show1
      +Show2
      +...
  +External disk 2
    +Films
    +TV Shows
  +...</code></pre>


When I started using XBMC-PVR somewhen in March the generated filenames for PVR-recordings seemed to change when recordings where added and removed. So I came up with my own fixed filename suitable for the library, which is simular to the original VDR file structure:

<code>pvr://recordings/<fullpath>/<date>/<title>.pvr</code>

As I have only one client, I also removed the client ID. I'm wondering if it is independent of the client adding sequence by the way.

Furthermore I have added a solution for adding TV show episodes. The idea is to change the subtitle information (the "S" tag) in the VDR info file by hand to the following (with respective translation):

<code>TV show - <episode-id> - <title></code>

The directory structure must be like in the following example (which is the standard structure, when VDR is programmed for repeated recordings):

<code><some path>/<tvshow>/<subdir>/<date></code>

The resulting filename for the episode in XBMC will than be:

<code>pvr://recordings/<some path>/<tvshow>/<date>/<tvshow> - <episode-id> - <title>.pvr</code>

Probably especially the TV show solution is not perfect but it's simple and it works well for VDR recordings.
