### PR TITLE
Added GenreType and GenreSubType to TimerInfoTag

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -211,6 +211,8 @@ inline void PVRWriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIMER
   addonTimer.strSummary        = xbmcTimer.m_strSummary.c_str();
   addonTimer.iMarginStart      = xbmcTimer.m_iMarginStart;
   addonTimer.iMarginEnd        = xbmcTimer.m_iMarginEnd;
+  addonTimer.iGenreType        = xbmcTimer.m_iGenreType;
+  addonTimer.iGenreSubType     = xbmcTimer.m_iGenreSubType;
 }
 
 /*!

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -58,6 +58,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(void)
   m_iMarginStart       = g_guiSettings.GetInt("pvrrecord.marginstart");
   m_iMarginEnd         = g_guiSettings.GetInt("pvrrecord.marginend");
   m_strGenre           = "";
+  m_iGenreType         = 0;
+  m_iGenreSubType      = 0;
   m_StartTime          = CDateTime::GetUTCDateTime();
   m_StopTime           = m_StartTime;
   m_state              = PVR_TIMER_STATE_SCHEDULED;
@@ -83,6 +85,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, CPVRChannel *channel,
   m_iMarginStart       = timer.iMarginStart;
   m_iMarginEnd         = timer.iMarginEnd;
   m_strGenre           = CEpg::ConvertGenreIdToString(timer.iGenreType, timer.iGenreSubType);
+  m_iGenreType         = timer.iGenreType;
+  m_iGenreSubType      = timer.iGenreSubType;
   m_epgInfo            = NULL;
   m_channel            = channel;
   m_bIsRadio           = channel && channel->IsRadio();
@@ -93,7 +97,11 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, CPVRChannel *channel,
   {
     m_epgInfo = channel->GetEPG()->GetTag(timer.iEpgUid, m_StartTime);
     if (m_epgInfo)
+    {
       m_strGenre = m_epgInfo->Genre();
+      m_iGenreType = m_epgInfo->GenreType();
+      m_iGenreSubType = m_epgInfo->GenreSubType();
+    }
   }
 
   UpdateSummary();
@@ -308,12 +316,15 @@ bool CPVRTimerInfoTag::UpdateEntry(const CPVRTimerInfoTag &tag)
   m_iMarginEnd        = tag.m_iMarginEnd;
   m_epgInfo           = tag.m_epgInfo;
   m_strGenre          = tag.m_strGenre;
-
+  m_iGenreType        = tag.m_iGenreType;
+  m_iGenreSubType     = tag.m_iGenreSubType;
   /* try to find an epg event */
   UpdateEpgEvent();
   if (m_epgInfo != NULL)
   {
     m_strGenre = m_epgInfo->Genre();
+    m_iGenreType = m_epgInfo->GenreType();
+    m_iGenreSubType = m_epgInfo->GenreSubType();
     m_epgInfo->SetTimer(this);
   }
 
@@ -471,6 +482,8 @@ CPVRTimerInfoTag *CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTag &tag)
   newTag->m_iClientChannelUid = channel->UniqueID();
   newTag->m_iClientId         = channel->ClientID();
   newTag->m_bIsRadio          = channel->IsRadio();
+  newTag->m_iGenreType        = tag.GenreType();
+  newTag->m_iGenreSubType     = tag.GenreSubType();
   newTag->SetStartFromUTC(newStart);
   newTag->SetEndFromUTC(newEnd);
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -86,6 +86,8 @@ namespace PVR
     unsigned int          m_iMarginStart;       /*!< @brief (optional) if set, the backend starts the recording iMarginStart minutes before startTime. */
     unsigned int          m_iMarginEnd;         /*!< @brief (optional) if set, the backend ends the recording iMarginEnd minutes after endTime. */
     CStdString            m_strGenre;           /*!< @brief genre of the timer */
+    int                   m_iGenreType;         /*!< @brief genre type of the timer */
+    int                   m_iGenreSubType;      /*!< @brief genre subtype of the timer */
 
     CPVRTimerInfoTag(void);
     CPVRTimerInfoTag(const PVR_TIMER &timer, CPVRChannel *channel, unsigned int iClientId);


### PR DESCRIPTION
I need it for scheduling a new recording in MythTV. The code will also be more consistent when it is included here (as it is used in the EPG). 
