### PR TITLE
[PR] Fix scraping of PVR files (update)

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -178,6 +178,7 @@ void CPVRRecording::UpdatePath(void)
   CStdString strTitle = m_strTitle;
   CStdString strDatetime = m_recordingTime.GetAsSaveString();
   strTitle.Replace('/','-');
+  strTitle.Remove('?');
 
   if (m_strDirectory != "")
     m_strFileNameAndPath.Format("pvr://recordings/%s/%s/%s.pvr",

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -108,6 +108,8 @@ void CSettings::Initialize()
   m_discStubExtensions = ".disc";
   // internal music extensions
   m_musicExtensions += "|.sidstream|.oggstream|.nsfstream|.asapstream|.cdda";
+  // internal video extensions
+  m_videoExtensions += "|.pvr";
 
   #ifdef __APPLE__
     CStdString logDir = getenv("HOME");


### PR DESCRIPTION
Added '.pvr' to known video extensions, seems that I have missed an update when testing #309. Also removed '?' from PVR filenames, which always causes troubles for TMDB and other scrapers.

I replaced my previous pull request #325 with this version to avoid merge conflicts.
