### PR TITLE
pvr: instant timer fix - starttime should be in UTC

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -446,12 +446,12 @@ CPVRTimerInfoTag *CPVRTimers::InstantTimer(CPVRChannel *channel, bool bStartTime
         newTimer->EndAsLocalTime().GetAsLocalizedTime("", false));
   }
 
-  CDateTime startTime;
+  CDateTime startTime(0);
   newTimer->SetStartFromUTC(startTime);
   newTimer->m_iMarginStart = 0; /* set the start margin to 0 for instant timers */
 
   int iDuration = g_guiSettings.GetInt("pvrrecord.instantrecordtime");
-  CDateTime endTime = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() + CDateTimeSpan(0, 0, iDuration ? iDuration : 120, 0);
+  CDateTime endTime = CDateTime::GetUTCDateTime() + CDateTimeSpan(0, 0, iDuration ? iDuration : 120, 0);
   newTimer->SetEndFromUTC(endTime);
 
   /* unused only for reference */


### PR DESCRIPTION
Instant timers didn't use UTC as start time
