### PR TITLE
fix table creation in pvr/epg databases when using mysql as a database s...

### DIFF
--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -83,7 +83,7 @@ bool CEpgDatabase::CreateTables(void)
           "iEpisodeId      integer, "
           "iEpisodePart    integer, "
           "sEpisodeName    varchar(128)"
-        ");"
+        ")"
     );
     m_pDS->exec("CREATE UNIQUE INDEX idx_epg_idEpg_iStartTime on epgtags(idEpg, iStartTime desc);");
     m_pDS->exec("CREATE INDEX idx_epg_iEndTime on epgtags(iEndTime);");

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -62,7 +62,7 @@ bool CPVRDatabase::CreateTables()
           "idClient integer primary key, "
           "sName    varchar(64), "
           "sUid     varchar(32)"
-        ");"
+        ")"
     );
 
     CLog::Log(LOGDEBUG, "PVRDB - %s - creating table 'channels'", __FUNCTION__);
@@ -87,7 +87,7 @@ bool CPVRDatabase::CreateTables()
           "iEncryptionSystem    integer, "
 
           "idEpg                integer"
-        ");"
+        ")"
     );
     m_pDS->exec("CREATE UNIQUE INDEX idx_channels_iClientId_iUniqueId on channels(iClientId, iUniqueId);");
 
@@ -111,7 +111,7 @@ bool CPVRDatabase::CreateTables()
           "idGroup    integer primary key,"
           "bIsRadio   bool, "
           "sName      varchar(64)"
-        ");"
+        ")"
     );
     m_pDS->exec("CREATE INDEX idx_channelgroups_bIsRadio on channelgroups(bIsRadio);");
 
@@ -121,7 +121,7 @@ bool CPVRDatabase::CreateTables()
           "idChannel      integer, "
           "idGroup        integer, "
           "iChannelNumber integer"
-        ");"
+        ")"
     );
     m_pDS->exec("CREATE UNIQUE INDEX idx_idGroup_idChannel on map_channelgroups_channels(idGroup, idChannel);");
 
@@ -155,7 +155,7 @@ bool CPVRDatabase::CreateTables()
           "bPostProcess         bool, "
           "iScalingMethod       integer, "
           "iDeinterlaceMode     integer "
-        ");"
+        ")"
     );
 
     bReturn = true;


### PR DESCRIPTION
...erver
This is part of a previous PR, will try to figure out a solution for the query you didn't approve later.
This one is ok (tables are never created in mysql otherwise, since the mysql dataset appends primary key info at the end of the query, which can't happen when there is a ';')
