### PR TITLE
Fix visualization on PVR radio channel playback

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2429,9 +2429,7 @@ bool CDVDPlayer::HasVideo() const
 {
   if (m_pInputStream)
   {
-    if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) ||
-        m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) ||
-        m_CurrentVideo.id >= 0) return true;
+    if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || m_CurrentVideo.id >= 0) return true;
   }
   return false;
 }


### PR DESCRIPTION
I finally figured out why the visualization didn't work anymore when playing radio channels in fullscreen mode.

This pull request reverts the following commit from FernetMenta:
"pvr: do not show background image or black screen when switching..."
52af67a03b0288cf1a318012c1e0fd4b23030235.

The full screen visualization only becomes active when HasVideo() returns false
