### PR TITLE
pvr: check for deleted channel groups after fetching from client and delete them (if any)

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -213,6 +213,22 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
 bool CPVRChannelGroups::UpdateGroupsEntries(const CPVRChannelGroups &groups)
 {
   CSingleLock lock(m_critSection);
+  /* go through groups list and check for deleted groups */
+  for (unsigned int iGroupPtr = 0; iGroupPtr < size(); iGroupPtr++)
+  {
+    CPVRChannelGroup *existingGroup = at(iGroupPtr);
+    if (!existingGroup->IsInternalGroup())
+    {
+      CPVRChannelGroup *group = (CPVRChannelGroup *) groups.GetByName(existingGroup->GroupName());
+      if (group == NULL)
+      {
+        CLog::Log(LOGDEBUG, "PVRChannelGroups - %s - User defined group %s with GroupID %u does not exist in client anymore, deleting",
+            __FUNCTION__, existingGroup->GroupName().c_str(), existingGroup->GroupID());
+        DeleteGroup(*at(iGroupPtr));
+        iGroupPtr--;
+      }
+    }
+  }
   /* go through the groups list and check for new groups */
   for (unsigned int iGroupPtr = 0; iGroupPtr < groups.size(); iGroupPtr++)
   {


### PR DESCRIPTION
At the moment there is no check for deleted channel groups, which leads to the fact that they are never deleted from XBMC. This fixes it (tested ok)
