### PR TITLE
optimize epg updating by updating/persisting only changes to tags... 

### DIFF
--- a/xbmc/epg/Epg.h
+++ b/xbmc/epg/Epg.h
@@ -193,9 +193,10 @@ namespace EPG
      * @brief Update an entry in this EPG.
      * @param tag The tag to update.
      * @param bUpdateDatabase If set to true, this event will be persisted in the database.
+     * @param bSort If set to false, epg entries will not be sorted after updating; used for mass updates
      * @return True if it was updated successfully, false otherwise.
      */
-    virtual bool UpdateEntry(const CEpgInfoTag &tag, bool bUpdateDatabase = false);
+    virtual bool UpdateEntry(const CEpgInfoTag &tag, bool bUpdateDatabase = false, bool bSort = true);
 
     /*!
      * @brief Update the EPG from 'start' till 'end'.
@@ -291,9 +292,10 @@ namespace EPG
 
     /*!
      * @brief Fix overlapping events from the tables.
+     * @param bUpdateDb If set to yes, any changes to tags during fixing will be persisted to database
      * @return True if anything changed, false otherwise.
      */
-    virtual bool FixOverlappingEvents(void);
+    virtual bool FixOverlappingEvents(bool bUpdateDb = false);
 
     /*!
      * @brief Sort all entries in this EPG by date.

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -390,11 +390,6 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
   tag.FirstAiredAsUTC().GetAsTime(iFirstAired);
   int iEpgId = epg->EpgID();
 
-  if (bSingleUpdate)
-  {
-    Delete(*tag.GetTable(), iStartTime, iEndTime);
-  }
-
   int iBroadcastId = tag.BroadcastId();
   CSingleLock lock(m_critSection);
   CStdString strQuery;

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -722,11 +722,10 @@ void CEpgInfoTag::Update(const EPG_TAG &tag)
   SetIcon(tag.strIconPath);
 }
 
-bool CEpgInfoTag::Update(const CEpgInfoTag &tag)
+bool CEpgInfoTag::Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId /* = true */)
 {
   CSingleLock lock(m_critSection);
   bool bChanged = (
-      m_iBroadcastId       != tag.m_iBroadcastId ||
       m_strTitle           != tag.m_strTitle ||
       m_strPlotOutline     != tag.m_strPlotOutline ||
       m_strPlot            != tag.m_strPlot ||
@@ -745,10 +744,14 @@ bool CEpgInfoTag::Update(const CEpgInfoTag &tag)
       m_iUniqueBroadcastID != tag.m_iUniqueBroadcastID ||
       ( tag.m_strGenre.length() > 0 && m_strGenre != tag.m_strGenre )
   );
+  if (bUpdateBroadcastId)
+    bChanged = bChanged || m_iBroadcastId != tag.m_iBroadcastId;
 
   if (bChanged)
   {
-    m_iBroadcastId       = tag.m_iBroadcastId;
+    if (bUpdateBroadcastId)
+      m_iBroadcastId       = tag.m_iBroadcastId;
+
     m_strTitle           = tag.m_strTitle;
     m_strPlotOutline     = tag.m_strPlotOutline;
     m_strPlot            = tag.m_strPlot;
@@ -789,7 +792,7 @@ bool CEpgInfoTag::Persist(bool bSingleUpdate /* = true */)
   CSingleLock lock(m_critSection);
   if (!m_bChanged)
     return true;
-
+  CLog::Log(LOGDEBUG, "Epg - %s - Infotag '%s' %s, persisting...", __FUNCTION__, m_strTitle.c_str(), m_iBroadcastId > 0 ? "has changes" : "is new");
   CEpgDatabase *database = g_EpgContainer.GetDatabase();
   if (!database || (bSingleUpdate && !database->Open()))
   {

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -394,9 +394,10 @@ namespace EPG
     /*!
      * @brief Update the information in this tag with the info in the given tag.
      * @param tag The new info.
+     * @param bUpdateBroadcastId If set to false, the tag BroadcastId (locally unique) will not be chacked/updated
      * @return True if something changed, false otherwise.
      */
-    virtual bool Update(const CEpgInfoTag &tag);
+    virtual bool Update(const CEpgInfoTag &tag, bool bUpdateBroadcastId = true);
 
   protected:
     /*!


### PR DESCRIPTION
...(instead of deleting/inserting all tags from scratch on every update)
should improve performance of epg updates due to the fact that most of the work is done in-memory.

Tested this overnight in 2 installations (both sqlite and mysql) and it worked ok in both. This is almost the first time that I check xbmc on the next day (after leaving it on overnight) and epg is not messed-up one way or another.

Please check
