### PR TITLE
jsonrpc: fix PVR.ScheduleRecording after r:baa4a7ec

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -204,18 +204,19 @@ JSON_STATUS CPVROperations::ScheduleRecording(const CStdString &method, ITranspo
 
       CPVRTimerInfoTag *newTimer = CPVRTimerInfoTag::CreateFromEpg(*tag);
       bool bCreated = (newTimer != NULL);
+      bool bAdded = false;
 
       if (bCreated)
       {
         CLog::Log(LOGDEBUG, "JSONRPC: recording scheduled");
-        delete newTimer;
-        return ACK;
+        bAdded = CPVRTimers::AddTimer(*newTimer);
       }
       else
       {
         CLog::Log(LOGERROR, "JSONRPC: failed to schedule recording");
-        return InternalError;
       }
+      delete newTimer;
+      return bAdded ? ACK : InternalError;
     }
   }
 


### PR DESCRIPTION
@opdenkamp while refactoring you forgot about 1 line :D 

CPVRTimers::AddTimer(*newTimer);

Regards 
FSSDawid :) 
