### PR TITLE
vnsi: retry connecting within timout

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -68,8 +68,15 @@ bool cVNSISession::Open(const std::string& hostname, int port, const char *name)
 {
   Close();
 
+  cTimeMs RetryTimeout;
   char errbuf[128];
-  m_fd = tcp_connect(hostname.c_str(), port, errbuf, sizeof(errbuf), g_iConnectTimeout * 1000);
+  m_fd = INVALID_SOCKET;
+  while (m_fd == INVALID_SOCKET && RetryTimeout.Elapsed() < (uint)g_iConnectTimeout * 1000)
+  {
+    m_fd = tcp_connect(hostname.c_str(), port, errbuf, sizeof(errbuf),
+        g_iConnectTimeout * 1000 - RetryTimeout.Elapsed());
+    SleepMs(100);
+  }
 
   if (m_fd == INVALID_SOCKET)
   {


### PR DESCRIPTION
I just found this commit lingering in an outdated branch. It fixes 
http://forum.xbmc.org/showthread.php?p=973228&posted=1#post973228

I recommend to backport this to Eden-pvr. I am using this myself for more than 6 months.
