### PR TITLE
Restore channels in group in the correct order.

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -659,7 +659,7 @@ int CPVRDatabase::GetGroupMembers(CPVRChannelGroup &group)
     return -1;
   }
 
-  CStdString strQuery = FormatSQL("SELECT idChannel, iChannelNumber FROM map_channelgroups_channels WHERE idGroup = %u", group.GroupID());
+  CStdString strQuery = FormatSQL("SELECT idChannel, iChannelNumber FROM map_channelgroups_channels WHERE idGroup = %u ORDER BY iChannelNumber", group.GroupID());
   if (ResultQuery(strQuery))
   {
     iReturn = 0;


### PR DESCRIPTION
If there is no ORDER BY clause, result rows are returned in no particular order. 
While adding channel to group and some channel has been skipped in database result, this one is assigned to the first free number.

Assigning to next free number is ok in most scenarios except for loading groups from database.
