### PR TITLE
TVHeadend compile fixes for Windows

### DIFF
--- a/lib/platform/windows/os-types.h
+++ b/lib/platform/windows/os-types.h
@@ -55,10 +55,10 @@ typedef SOCKET tcp_socket_t;
 typedef HANDLE serial_socket_t;
 #define INVALID_SERIAL_SOCKET_VALUE INVALID_HANDLE_VALUE
 
-typedef signed __int8    int8_t;
-typedef signed __int16   int16_t;
-typedef signed __int32   int32_t;
-typedef signed __int64   int64_t;
+typedef __int8    int8_t;
+typedef __int16   int16_t;
+typedef __int32   int32_t;
+typedef __int64   int64_t;
 typedef unsigned __int8  uint8_t;
 typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;

--- a/xbmc/pvrclients/tvheadend/HTSPDemux.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPDemux.cpp
@@ -21,8 +21,8 @@
 
 #include <stdint.h>
 #include <limits.h>
-#include <libavcodec/avcodec.h> // For codec id's
 #include "HTSPDemux.h"
+#include <libavcodec/avcodec.h> // For codec id's
 
 extern "C" {
 #include "libhts/net.h"


### PR DESCRIPTION
Hi Lars,

A few compile fixes for the tvheadend addon under Windows (VS2010).
Please check if you agree with 790f448a76e03157f778d8a7d9be2276589fcbed.

Grt,
Marcel
