### PR TITLE
Pvr tvheadend fix

### DIFF
--- a/xbmc/pvrclients/tvheadend/HTSPConnection.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPConnection.cpp
@@ -159,8 +159,10 @@ htsmsg_t* CHTSPConnection::ReadMessage(int iInitialTimeout /* = 10000 */, int iD
 
     if (m_socket->Read(&l, 4, iInitialTimeout) != 4)
     {
-      if(m_socket->GetErrorNumber() != ETIMEDOUT && m_socket->GetErrorNumber() != 0)
-        XBMC->Log(LOG_ERROR, "%s - Failed to read packet size (%s)", __FUNCTION__, m_socket->GetError().c_str());
+      if(m_socket->GetErrorNumber() == ETIMEDOUT)
+        return htsmsg_create_map();
+
+      XBMC->Log(LOG_ERROR, "%s - Failed to read packet size (%s)", __FUNCTION__, m_socket->GetError().c_str());
       return NULL;
     }
 

--- a/xbmc/pvrclients/tvheadend/HTSPDemux.h
+++ b/xbmc/pvrclients/tvheadend/HTSPDemux.h
@@ -53,7 +53,6 @@ private:
   bool ParseSourceInfo(htsmsg_t* msg);
 
   CHTSPConnection      *m_session;
-  bool                  m_bGotFirstIframe;
   bool                  m_bIsRadio;
   bool                  m_bAbort;
   bool                  m_bResetNeeded;


### PR DESCRIPTION
Current PVR code aborts playback if addon returns a NULL demux packet, so remove the chances of that happening.
