### PR TITLE
Change icon if path is different

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -73,6 +73,7 @@ bool CPVRDatabase::CreateTables()
           "iUniqueId            integer, "
           "bIsRadio             bool, "
           "bIsHidden            bool, "
+          "bIsUserSetIcon       bool, "
           "sIconPath            varchar(255), "
           "sChannelName         varchar(64), "
           "bIsVirtual           bool, "
@@ -255,6 +256,8 @@ bool CPVRDatabase::UpdateOldVersion(int iVersion)
           database.Close();
         }
       }
+      if (iVersion < 20)
+        m_pDS->exec("ALTER TABLE channels ADD bIsUserSetIcon bool;");
     }
   }
   catch (...)
@@ -315,11 +318,11 @@ int CPVRDatabase::Persist(const CPVRChannel &channel, bool bQueueWrite /* = fals
   {
     /* new channel */
     strQuery = FormatSQL("INSERT INTO channels ("
-        "iUniqueId, bIsRadio, bIsHidden, "
+        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idEpg) "
-        "VALUES (%i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i);",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0),
+        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i);",
+        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(),
         channel.EpgID());
@@ -328,11 +331,11 @@ int CPVRDatabase::Persist(const CPVRChannel &channel, bool bQueueWrite /* = fals
   {
     /* update channel */
     strQuery = FormatSQL("REPLACE INTO channels ("
-        "iUniqueId, bIsRadio, bIsHidden, "
+        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idChannel, idEpg) "
-        "VALUES (%i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i);",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0),
+        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i);",
+        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(), channel.ChannelID(),
         channel.EpgID());
@@ -365,7 +368,7 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
 {
   int iReturn = 0;
 
-  CStdString strQuery = FormatSQL("SELECT channels.idChannel, channels.iUniqueId, channels.bIsRadio, channels.bIsHidden, "
+  CStdString strQuery = FormatSQL("SELECT channels.idChannel, channels.iUniqueId, channels.bIsRadio, channels.bIsHidden, channels.bIsUserSetIcon, "
       "channels.sIconPath, channels.sChannelName, channels.bIsVirtual, channels.bEPGEnabled, channels.sEPGScraper, channels.iLastWatched, channels.iClientId, "
       "channels.iClientChannelNumber, channels.sInputFormat, channels.sInputFormat, channels.sStreamURL, channels.iEncryptionSystem, map_channelgroups_channels.iChannelNumber, channels.idEpg "
       "FROM map_channelgroups_channels "
@@ -383,6 +386,7 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
         channel->m_iUniqueId               = m_pDS->fv("iUniqueId").get_asInt();
         channel->m_bIsRadio                = m_pDS->fv("bIsRadio").get_asBool();
         channel->m_bIsHidden               = m_pDS->fv("bIsHidden").get_asBool();
+        channel->m_bIsUserSetIcon          = m_pDS->fv("bIsUserSetIcon").get_asBool();
         channel->m_strIconPath             = m_pDS->fv("sIconPath").get_asString();
         channel->m_strChannelName          = m_pDS->fv("sChannelName").get_asString();
         channel->m_bIsVirtual              = m_pDS->fv("bIsVirtual").get_asBool();

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -257,7 +257,7 @@ bool CPVRDatabase::UpdateOldVersion(int iVersion)
         }
       }
       if (iVersion < 20)
-        m_pDS->exec("ALTER TABLE channels ADD bIsUserSetIcon bool;");
+        m_pDS->exec("ALTER TABLE channels ADD bIsUserSetIcon bool");
     }
   }
   catch (...)
@@ -321,7 +321,7 @@ int CPVRDatabase::Persist(const CPVRChannel &channel, bool bQueueWrite /* = fals
         "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idEpg) "
-        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i);",
+        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i)",
         channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(),
@@ -334,7 +334,7 @@ int CPVRDatabase::Persist(const CPVRChannel &channel, bool bQueueWrite /* = fals
         "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idChannel, idEpg) "
-        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i);",
+        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i)",
         channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(), channel.ChannelID(),

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -57,7 +57,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetMinVersion() const { return 19; };
+    virtual int GetMinVersion() const { return 20; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -196,7 +196,7 @@ bool CPVRChannel::UpdateFromClient(const CPVRChannel &channel)
   if (m_strChannelName.IsEmpty())
     SetChannelName(channel.ClientChannelName());
   if (m_strIconPath.IsEmpty()||(!m_strIconPath.Equals(channel.IconPath()) && !IsUserSetIcon()))
-    SetIconPath(channel.IconPath());
+    SetIconPath(channel.IconPath(), false, false);
 
   return m_bChanged;
 }
@@ -284,7 +284,7 @@ bool CPVRChannel::IsRecording(void) const
   return g_PVRTimers->IsRecordingOnChannel(*this);
 }
 
-bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bSaveInDb /* = false */, bool bIsUserSetIcon /* = false */)
+bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bSaveInDb /* = false */, bool bIsUserSetIcon /* = true */)
 {
   bool bReturn(true); // different from the behaviour of the rest of this class
   CSingleLock lock(m_critSection);
@@ -300,7 +300,7 @@ bool CPVRChannel::SetIconPath(const CStdString &strIconPath, bool bSaveInDb /* =
     SetChanged();
     m_bChanged = true;
 
-	/* did the user change the icon? */
+    /* did the user change the icon? */
     if (bIsUserSetIcon) {
       if (!m_strIconPath.IsEmpty()) {
         m_bIsUserSetIcon = true;

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -192,7 +192,7 @@ bool CPVRChannel::UpdateFromClient(const CPVRChannel &channel)
   CSingleLock lock(m_critSection);
   if (m_strChannelName.IsEmpty())
     SetChannelName(channel.ClientChannelName());
-  if (m_strIconPath.IsEmpty())
+  if (m_strIconPath.IsEmpty()||!m_strIconPath.Equals(channel.IconPath()))
     SetIconPath(channel.IconPath());
 
   return m_bChanged;

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -194,7 +194,7 @@ namespace PVR
      * @param bIsUserSetIcon true if user changed the icon via GUI, false otherwise.
      * @return True if the something changed, false otherwise.
      */
-    bool SetIconPath(const CStdString &strIconPath, bool bSaveInDb = false, bool bIsUserSetIcon = false);
+    bool SetIconPath(const CStdString &strIconPath, bool bSaveInDb = false, bool bIsUserSetIcon = true);
 
     /*!
      * @brief The name for this channel used by XBMC.

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -58,6 +58,7 @@ namespace PVR
     int              m_iChannelId;              /*!< the identifier given to this channel by the TV database */
     bool             m_bIsRadio;                /*!< true if this channel is a radio channel, false if not */
     bool             m_bIsHidden;               /*!< true if this channel is hidden, false if not */
+    bool             m_bIsUserSetIcon;          /*!< true if user set the icon via GUI, false if not */
     CStdString       m_strIconPath;             /*!< the path to the icon for this channel */
     CStdString       m_strChannelName;          /*!< the name for this channel used by XBMC */
     bool             m_bIsVirtual;              /*!< true if this channel is marked as virtual, false if not */
@@ -181,12 +182,19 @@ namespace PVR
     const CStdString &IconPath(void) const { return m_strIconPath; }
 
     /*!
+     * @brief True if this user changed icon via GUI. False if not.
+     * @return True if this user changed icon via GUI. False if not.
+     */
+    bool IsUserSetIcon(void) const { return m_bIsUserSetIcon; }
+	  
+    /*!
      * @brief Set the path to the icon for this channel.
      * @param strIconPath The new path.
      * @param bSaveInDb Save in the database or not.
+     * @param bIsUserSetIcon true if user changed the icon via GUI, false otherwise.
      * @return True if the something changed, false otherwise.
      */
-    bool SetIconPath(const CStdString &strIconPath, bool bSaveInDb = false);
+    bool SetIconPath(const CStdString &strIconPath, bool bSaveInDb = false, bool bIsUserSetIcon = false);
 
     /*!
      * @brief The name for this channel used by XBMC.

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -448,7 +448,7 @@ bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUT
       if (strThumb == "thumb://None")
         strThumb = "";
 
-      channel->SetIconPath(strThumb, true);
+      channel->SetIconPath(strThumb, true, true);
       UpdateData();
     }
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -448,7 +448,7 @@ bool CGUIWindowPVRChannels::OnContextButtonSetThumb(CFileItem *item, CONTEXT_BUT
       if (strThumb == "thumb://None")
         strThumb = "";
 
-      channel->SetIconPath(strThumb, true, true);
+      channel->SetIconPath(strThumb, true);
       UpdateData();
     }
 


### PR DESCRIPTION
If we change the icon url in the backend it should be also changed in the frontend.

Why is it even neccessary to check if m_strIconPath is empty? I may be better to drop the if sentence entirely.
