### PR TITLE
pvr: added support for timers in subdirectories

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -157,6 +157,7 @@ extern "C" {
     bool bSupportsChannelScan;          /*!< @brief (optional) true if this add-on support scanning for new channels on the backend */
     bool bHandlesInputStream;           /*!< @brief (optional) true if this add-on provides an input stream. false if XBMC handles the stream. */
     bool bHandlesDemuxing;              /*!< @brief (optional) true if this add-on demultiplexes packets. */
+    bool bSupportsRecordingFolders;     /*!< @brief (optional) true if the backend supports timers / recordings in folders. */
   } ATTRIBUTE_PACKED PVR_ADDON_CAPABILITIES;
 
   /*!

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -87,17 +87,18 @@ void CPVRClient::ResetProperties(void)
 
 void CPVRClient::ResetAddonCapabilities(void)
 {
-  m_addonCapabilities.bSupportsChannelSettings = false;
-  m_addonCapabilities.bSupportsTimeshift       = false;
-  m_addonCapabilities.bSupportsEPG             = false;
-  m_addonCapabilities.bSupportsTV              = false;
-  m_addonCapabilities.bSupportsRadio           = false;
-  m_addonCapabilities.bSupportsRecordings      = false;
-  m_addonCapabilities.bSupportsTimers          = false;
-  m_addonCapabilities.bSupportsChannelGroups   = false;
-  m_addonCapabilities.bSupportsChannelScan     = false;
-  m_addonCapabilities.bHandlesInputStream      = false;
-  m_addonCapabilities.bHandlesDemuxing         = false;
+  m_addonCapabilities.bSupportsChannelSettings  = false;
+  m_addonCapabilities.bSupportsTimeshift        = false;
+  m_addonCapabilities.bSupportsEPG              = false;
+  m_addonCapabilities.bSupportsTV               = false;
+  m_addonCapabilities.bSupportsRadio            = false;
+  m_addonCapabilities.bSupportsRecordings       = false;
+  m_addonCapabilities.bSupportsTimers           = false;
+  m_addonCapabilities.bSupportsChannelGroups    = false;
+  m_addonCapabilities.bSupportsChannelScan      = false;
+  m_addonCapabilities.bHandlesInputStream       = false;
+  m_addonCapabilities.bHandlesDemuxing          = false;
+  m_addonCapabilities.bSupportsRecordingFolders = false;
 }
 
 bool CPVRClient::Create(int iClientId)

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -41,6 +41,7 @@ using namespace PVR;
 #define CONTROL_TMR_LIFETIME            27
 #define CONTROL_TMR_FIRST_DAY           28
 #define CONTROL_TMR_NAME                29
+#define CONTROL_TMR_DIR                 30
 #define CONTROL_TMR_RADIO               50
 #define CONTROL_TMR_CHNAME_RADIO        51
 
@@ -140,6 +141,10 @@ void CGUIDialogPVRTimerSettings::CreateSettings()
   m_bTimerActive = tag->IsActive();
   AddBool(CONTROL_TMR_ACTIVE, 19074, &m_bTimerActive);
   AddButton(CONTROL_TMR_NAME, 19075, &tag->m_strTitle, true);
+
+  if (tag->SupportsFolders())
+    AddButton(CONTROL_TMR_DIR, 19076, &tag->m_strDirectory, true);
+
   AddBool(CONTROL_TMR_RADIO, 19077, &tag->m_bIsRadio);
 
   /// Channel names
@@ -240,6 +245,8 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(SettingInfo &setting)
       UpdateSetting(CONTROL_TMR_NAME);
     }
   }
+  if (setting.id == CONTROL_TMR_DIR && CGUIDialogKeyboard::ShowAndGetInput(tag->m_strDirectory, g_localizeStrings.Get(19104), false))
+      UpdateSetting(CONTROL_TMR_DIR);
   else if (setting.id == CONTROL_TMR_RADIO)
   {
     const CPVRChannel* channeltag = NULL;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -122,6 +122,7 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
           m_iLifetime          == right.m_iLifetime &&
           m_strFileNameAndPath == right.m_strFileNameAndPath &&
           m_strTitle           == right.m_strTitle &&
+          m_strDirectory       == right.m_strDirectory &&
           m_iClientId          == right.m_iClientId &&
           m_iMarginStart       == right.m_iMarginStart &&
           m_iMarginEnd         == right.m_iMarginEnd &&
@@ -144,6 +145,7 @@ CPVRTimerInfoTag &CPVRTimerInfoTag::operator=(const CPVRTimerInfoTag &orig)
   m_iLifetime          = orig.m_iLifetime;
   m_strFileNameAndPath = orig.m_strFileNameAndPath;
   m_strTitle           = orig.m_strTitle;
+  m_strDirectory       = orig.m_strDirectory;
   m_iClientId          = orig.m_iClientId;
   m_iMarginStart       = orig.m_iMarginStart;
   m_iMarginEnd         = orig.m_iMarginEnd;
@@ -618,3 +620,9 @@ EPG::CEpgInfoTag *CPVRTimerInfoTag::GetEpgInfoTag(void) const
     return epg->GetTag(-1, m_epgStart);
   return NULL;
 }
+
+bool CPVRTimerInfoTag::SupportsFolders() const
+{
+  return g_PVRClients->GetAddonCapabilities(m_iClientId).bSupportsRecordingFolders;
+}
+

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -146,6 +146,8 @@ namespace PVR
     unsigned int MarginEnd(void) const { return m_iMarginEnd; }
     void SetMarginEnd(unsigned int iMinutes) { m_iMarginEnd = iMinutes; }
 
+    bool SupportsFolders() const;
+
     /*!
      * @brief Show a notification for this timer in the UI
      */


### PR DESCRIPTION
This adds support for placing timers / recording into subdirectories.
The backend has to set the 'bSupportsDirectories' capability if it supports sub-directories.
