### PR TITLE
epg: move the initial loading of the epg tables to the epg thread...

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1801,6 +1801,7 @@
   <string id="19247">Daily wakeup</string>
   <string id="19248">Daily wakeup time (HH:MM:SS)</string>
   <string id="19249">Filter channels</string>
+  <string id="19250">Loading EPG from database</string>
   
   <string id="19499">Other/Unknown</string>
   <string id="19500">Movie/Drama</string>

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -383,6 +383,7 @@ bool CEpg::Load(void)
   }
   else
   {
+    m_lastScanTime = GetLastScanTime();
     CLog::Log(LOGDEBUG, "Epg - %s - %d entries loaded for table '%s'.",
         __FUNCTION__, (int) m_tags.size(), m_strName.c_str());
     bReturn = true;

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -171,8 +171,9 @@ namespace EPG
 
     /*!
      * @brief Show the progress bar
+     * @param bUpdating True if updating epg entries, false if just loading them from db
      */
-    virtual void ShowProgressDialog(void);
+    virtual void ShowProgressDialog(bool bUpdating = true);
 
     /*!
      * @brief Update the progress bar.
@@ -270,6 +271,7 @@ namespace EPG
     //@{
     bool         m_bIsUpdating;            /*!< true while an update is running */
     bool         m_bIsInitialising;        /*!< true while the epg manager hasn't loaded all tables */
+    bool         m_bLoaded;                /*!< true after epg data is initially loaded from the database */
     bool         m_bPreventUpdates;        /*!< true to prevent EPG updates */
     time_t       m_iLastEpgCleanup;        /*!< the time the EPG was cleaned up */
     time_t       m_iNextEpgUpdate;         /*!< the time the EPG will be updated */


### PR DESCRIPTION
...(instead of the main) while displaying a popup while loading for cosmetic reasons and don't reload them after pvr manager has started.
Also, update the displayed channel name before it's epg is updated (makes more sense).
