### PR TITLE
tvheadend: fix bad error returned by GetEPG when last event has a (norma...

### DIFF
--- a/xbmc/pvrclients/tvheadend/HTSPData.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPData.cpp
@@ -283,7 +283,7 @@ PVR_ERROR CHTSPData::GetEpg(PVR_HANDLE handle, const PVR_CHANNEL &channel, time_
         break;
       }
 
-    } while(iEnd > stop);
+    } while(iEnd > stop && event.id != 0);
   }
   else
   {


### PR DESCRIPTION
...l) next id of 0
