### PR TITLE
pvr/epg: don't lock while initially loading epg from the db; instead, let...

### DIFF
--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -206,6 +206,11 @@ namespace EPG
     bool IsInitialising(void) const;
 
     /*!
+    * @return True when EPG data has been initially loaded from the database.
+    */
+    bool IsLoaded(void) const;
+
+    /*!
      * @brief Call Persist() on each table
      * @return True when they all were persisted, false otherwise.
      */


### PR DESCRIPTION
...pvr and epg threads wait for each other to finish loading by checking states before running the main loops

After the changes introduced by 20bcef12591816994b3eedb08bdee0a8730ea, XBMC would have to wait for the  initial epg loading process before it could close (if requested in the meanwhile). This was because the loading of the epg was holding a lock to the mutex, so that the pvr thread would wait for the epg to load before it would load it's stuff (it would try to stop the epg process, and because of the lock, wait, and then restart it after loading the pvr stuff).
This, of course, does not seem good, so I came up with the method of this PR, where each thread will wait for each other to load the required stuff by checking the respective states.

I know you might moan because the eventual goal is to totally separate epg from pvr but at the moment they are still very much dependent, so I think it's better to have it working properly for now and figure out a final solution when the separation is implemented.
