### PR TITLE
pvr: fixed: retrieve channels from backend without syncchannelgroups

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -116,14 +116,11 @@ int CPVRChannelGroup::Load(void)
   CLog::Log(LOGDEBUG, "PVRChannelGroup - %s - %d channels loaded from the database for group '%s'",
         __FUNCTION__, iChannelCount, m_strGroupName.c_str());
 
-  if (g_guiSettings.GetBool("pvrmanager.syncchannelgroups"))
+  Update();
+  if (size() - iChannelCount > 0)
   {
-    Update();
-    if (size() - iChannelCount > 0)
-    {
-      CLog::Log(LOGDEBUG, "PVRChannelGroup - %s - %d channels added from clients to group '%s'",
-          __FUNCTION__, (int) size() - iChannelCount, m_strGroupName.c_str());
-    }
+    CLog::Log(LOGDEBUG, "PVRChannelGroup - %s - %d channels added from clients to group '%s'",
+        __FUNCTION__, (int) size() - iChannelCount, m_strGroupName.c_str());
   }
 
   SortByChannelNumber();

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -261,9 +261,15 @@ bool CPVRChannelGroups::LoadUserDefinedChannelGroups(void)
       __FUNCTION__, (int) (size() - iSize), m_bRadio ? "radio" : "TV");
 
   iSize = size();
-  GetGroupsFromClients();
-  CLog::Log(LOGDEBUG, "PVRChannelGroups - %s - %d new user defined %s channel groups fetched from clients",
-      __FUNCTION__, (int) (size() - iSize), m_bRadio ? "radio" : "TV");
+  if (g_guiSettings.GetBool("pvrmanager.syncchannelgroups"))
+  {
+    GetGroupsFromClients();
+    CLog::Log(LOGDEBUG, "PVRChannelGroups - %s - %d new user defined %s channel groups fetched from clients",
+        __FUNCTION__, (int) (size() - iSize), m_bRadio ? "radio" : "TV");
+  }
+  else
+    CLog::Log(LOGDEBUG, "PVRChannelGroups - %s - 'synchannelgroups' is disabled; skipping groups from clients",
+        __FUNCTION__);
 
   /* load group members */
   for (unsigned int iGroupPtr = 1; iGroupPtr < size(); iGroupPtr++)


### PR DESCRIPTION
With syncchannelgroups==false, XBMC should skip the backend groups, but still load the channels and add them to the internal TV and radio group instead of ignoring also the backend channels.
