### PR TITLE
Fix undefined symbols in MythTV PVR client

### DIFF
--- a/xbmc/pvrclients/mythtv/Makefile.in
+++ b/xbmc/pvrclients/mythtv/Makefile.in
@@ -5,7 +5,7 @@
 # how to reach the author.
 #
 
-LIBS   = -ldl
+LIBS   = libmythxml/libmythxml.a
 LIBDIR = @abs_top_srcdir@/addons/pvr.mythtv
 LIB    = @abs_top_srcdir@/addons/pvr.mythtv/XBMC_Mythtv.pvr
 

--- a/xbmc/pvrclients/mythtv/client.cpp
+++ b/xbmc/pvrclients/mythtv/client.cpp
@@ -292,7 +292,7 @@ PVR_ERROR GetEPGForChannel(PVR_HANDLE handle, const PVR_CHANNEL &channel, time_t
 /*******************************************/
 /** PVR Channel Functions                 **/
 
-int GetNumChannels()
+int GetChannelsAmount(void)
 {
 	if (MythXmlApi == NULL)
 		return PVR_ERROR_SERVER_ERROR;
@@ -306,6 +306,21 @@ PVR_ERROR GetChannels(PVR_HANDLE handle, bool bRadio)
 			return PVR_ERROR_SERVER_ERROR;
 
 	return MythXmlApi->requestChannelList(handle, bRadio);
+}
+
+int GetChannelGroupsAmount(void)
+{
+  return 0;
+}
+
+PVR_ERROR GetChannelGroups(PVR_HANDLE handle, bool bRadio)
+{
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
+PVR_ERROR GetChannelGroupMembers(PVR_HANDLE handle, const PVR_CHANNEL_GROUP &group)
+{
+  return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel)


### PR DESCRIPTION
The MythTV PVR client uses functionality from libmythxml.a but does not
link it in. Additionally, it fails to implement several PVR channel
functions, and has a wrong name for GetChannelsAmount(). Also, it is
linked against libdl which it doesn't use.

To fix the undefined symbols, make the client link against libmythxml.a,
add stubs for the missing functions, and change GetNumChannels() to
GetChannelsAmount(). Also drop unused -ldl from the linking command
line.

As noted previously, this is build-tested only (the patch just fixes the build).
