### PR TITLE
pvr: Set folder date to the date of the most recent recording it contain.

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -138,7 +138,15 @@ void CPVRRecordings::GetSubDirectories(const CStdString &strBase, CFileItemList 
       pFileItem->SetPath(strFilePath);
       pFileItem->SetLabel(strCurrent);
       pFileItem->SetLabelPreformated(true);
+      pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
       results->Add(pFileItem);
+    }
+    else
+    {
+      CFileItemPtr pFileItem;
+      pFileItem=results->Get(strFilePath);
+      if (pFileItem->m_dateTime<current->RecordingTimeAsLocalTime())
+        pFileItem->m_dateTime  = current->RecordingTimeAsLocalTime();
     }
   }
 


### PR DESCRIPTION
This will allow to sort the folder on Date in the recordings screen.
