### PR TITLE
PVR Parental control

### DIFF
--- a/addons/skin.confluence/720p/DialogPVRChannelManager.xml
+++ b/addons/skin.confluence/720p/DialogPVRChannelManager.xml
@@ -367,6 +367,27 @@
 					<onright>60</onright>
 					<onleft>20</onleft>
 					<onup>12</onup>
+					<ondown>14</ondown>
+				</control>
+				<control type="radiobutton" id ="14">
+					<description>Parental locked</description>
+					<posx>0</posx>
+					<posy>225</posy>
+					<width>380</width>
+					<height>35</height>
+					<font>font12</font>
+					<textcolor>white</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<shadowcolor>black</shadowcolor>
+					<align>left</align>
+					<aligny>center</aligny>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<texturenofocus border="5">button-nofocus.png</texturenofocus>
+					<pulseonselect>no</pulseonselect>
+					<label>19267</label>
+					<onleft>20</onleft>
+					<onright>60</onright>
+					<onup>13</onup>
 					<ondown>30</ondown>
 				</control>
 			</control>
@@ -399,7 +420,7 @@
 					<label>19205</label>
 					<onleft>20</onleft>
 					<onright>34</onright>
-					<onup>13</onup>
+					<onup>14</onup>
 					<ondown>31</ondown>
 				</control>
 				<control type="button" id ="34">
@@ -416,7 +437,7 @@
 					<label>19024</label>
 					<onleft>30</onleft>
 					<onright>60</onright>
-					<onup>13</onup>
+					<onup>14</onup>
 					<ondown>31</ondown>
 				</control>
 				<control type="button" id ="34">
@@ -433,7 +454,7 @@
 					<label>19023</label>
 					<onleft>30</onleft>
 					<onright>60</onright>
-					<onup>13</onup>
+					<onup>14</onup>
 					<ondown>31</ondown>
 				</control>
 				<control type="button" id ="31">

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7074,6 +7074,50 @@ msgctxt "#19256"
 msgid "Stop recording"
 msgstr ""
 
+msgctxt "#19257"
+msgid "Lock channel"
+msgstr ""
+
+msgctxt "#19258"
+msgid "Unlock channel"
+msgstr ""
+
+msgctxt "#19259"
+msgid "Parental control"
+msgstr ""
+
+msgctxt "#19260"
+msgid "Unlock duration"
+msgstr ""
+
+msgctxt "#19261"
+msgid "Change PIN"
+msgstr ""
+
+msgctxt "#19262"
+msgid "Parental control. Enter PIN:"
+msgstr ""
+
+msgctxt "#19263"
+msgid "Locked channel. Enter PIN:"
+msgstr ""
+
+msgctxt "#19264"
+msgid "Incorrect PIN"
+msgstr ""
+
+msgctxt "#19265"
+msgid "The entered PIN number was incorrect."
+msgstr ""
+
+msgctxt "#19266"
+msgid "Parental locked"
+msgstr ""
+
+msgctxt "#19267"
+msgid "Parental locked:"
+msgstr ""
+
 msgctxt "#19499"
 msgid "Other/Unknown"
 msgstr ""

--- a/xbmc/GUIViewControl.cpp
+++ b/xbmc/GUIViewControl.cpp
@@ -62,7 +62,7 @@ void CGUIViewControl::SetParentWindow(int window)
   m_parentWindow = window;
 }
 
-void CGUIViewControl::SetCurrentView(int viewMode)
+void CGUIViewControl::SetCurrentView(int viewMode, bool bRefresh /* = false */)
 {
   // grab the previous control
   CGUIControl *previousView = NULL;
@@ -99,7 +99,7 @@ void CGUIViewControl::SetCurrentView(int viewMode)
     (*view)->SetVisible(false);
   pNewView->SetVisible(true);
 
-  if (pNewView == previousView)
+  if (!bRefresh && pNewView == previousView)
     return; // no need to actually update anything (other than visibility above)
 
 //  CLog::Log(LOGDEBUG,"SetCurrentView: Oldview: %i, Newview :%i", m_currentView, viewMode);

--- a/xbmc/GUIViewControl.h
+++ b/xbmc/GUIViewControl.h
@@ -36,7 +36,7 @@ public:
   void AddView(const CGUIControl *control);
   void SetViewControlID(int control);
 
-  void SetCurrentView(int viewMode);
+  void SetCurrentView(int viewMode, bool bRefresh = false);
 
   void SetItems(CFileItemList &items);
 

--- a/xbmc/epg/EpgDatabase.cpp
+++ b/xbmc/epg/EpgDatabase.cpp
@@ -415,7 +415,7 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid) "
         "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i);",
         tag.EpgID(), iStartTime, iEndTime,
-        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
+        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         iFirstAired, tag.ParentalRating(), tag.StarRating(), tag.Notify(),
         tag.SeriesNum(), tag.EpisodeNum(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.UniqueBroadcastID());
@@ -428,7 +428,7 @@ int CEpgDatabase::Persist(const CEpgInfoTag &tag, bool bSingleUpdate /* = true *
         "iEpisodeId, iEpisodePart, sEpisodeName, iBroadcastUid, idBroadcast) "
         "VALUES (%u, %u, %u, '%s', '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, %i);",
         tag.EpgID(), iStartTime, iEndTime,
-        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
+        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         iFirstAired, tag.ParentalRating(), tag.StarRating(), tag.Notify(),
         tag.SeriesNum(), tag.EpisodeNum(), tag.EpisodePart(), tag.EpisodeName().c_str(),
         tag.UniqueBroadcastID(), iBroadcastId);

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -399,13 +399,19 @@ void CEpgInfoTag::SetTitle(const CStdString &strTitle)
     UpdatePath();
 }
 
-CStdString CEpgInfoTag::Title(void) const
+CStdString CEpgInfoTag::Title(bool bOverrideParental /* = false */) const
 {
   CStdString retVal;
   CSingleLock lock(m_critSection);
   retVal = (m_strTitle.IsEmpty()) ?
       g_localizeStrings.Get(19055) :
       m_strTitle;
+
+  if (!bOverrideParental && !g_PVRManager.CheckParentalOverride(ChannelTag())) 
+  {
+    retVal = g_localizeStrings.Get(19266);
+  }
+
   return retVal;
 }
 
@@ -425,11 +431,17 @@ void CEpgInfoTag::SetPlotOutline(const CStdString &strPlotOutline)
     UpdatePath();
 }
 
-CStdString CEpgInfoTag::PlotOutline(void) const
+CStdString CEpgInfoTag::PlotOutline(bool bOverrideParental /* = false */) const
 {
   CStdString retVal;
   CSingleLock lock(m_critSection);
   retVal = m_strPlotOutline;
+
+  if (!bOverrideParental && !g_PVRManager.CheckParentalOverride(ChannelTag())) 
+  {
+    retVal = "";
+  }
+
   return retVal;
 }
 
@@ -453,11 +465,17 @@ void CEpgInfoTag::SetPlot(const CStdString &strPlot)
     UpdatePath();
 }
 
-CStdString CEpgInfoTag::Plot(void) const
+CStdString CEpgInfoTag::Plot(bool bOverrideParental /* = false */) const
 {
   CStdString retVal;
   CSingleLock lock(m_critSection);
   retVal = m_strPlot;
+
+  if (!bOverrideParental && !g_PVRManager.CheckParentalOverride(ChannelTag())) 
+  {
+    retVal = "";
+  }
+
   return retVal;
 }
 

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -182,9 +182,10 @@ namespace EPG
 
     /*!
      * @brief Get the title of this event.
+     * @param bOverrideParental True to override parental control, false check it.
      * @return The title.
      */
-    virtual CStdString Title(void) const;
+    virtual CStdString Title(bool bOverrideParental = false) const;
 
     /*!
      * @brief Change the plot outline of this event.
@@ -194,9 +195,10 @@ namespace EPG
 
     /*!
      * @brief Get the plot outline of this event.
+     * @param bOverrideParental True to override parental control, false check it.
      * @return The plot outline.
      */
-    virtual CStdString PlotOutline(void) const;
+    virtual CStdString PlotOutline(bool bOverrideParental = false) const;
 
     /*!
      * @brief Change the plot of this event.
@@ -206,9 +208,10 @@ namespace EPG
 
     /*!
      * @brief Get the plot of this event.
+     * @param bOverrideParental True to override parental control, false check it.
      * @return The plot.
      */
-    virtual CStdString Plot(void) const;
+    virtual CStdString Plot(bool bOverrideParental = false) const;
 
     /*!
      * @brief Change the genre of this event.

--- a/xbmc/epg/EpgSearchFilter.cpp
+++ b/xbmc/epg/EpgSearchFilter.cpp
@@ -100,8 +100,8 @@ bool EpgSearchFilter::MatchSearchTerm(const CEpgInfoTag &tag) const
   if (!m_strSearchTerm.IsEmpty())
   {
     CTextSearch search(m_strSearchTerm, m_bIsCaseSensitive, SEARCH_DEFAULT_OR);
-    bReturn = search.Search(tag.Title()) ||
-        search.Search(tag.PlotOutline());
+    bReturn = search.Search(tag.Title(true)) ||
+        search.Search(tag.PlotOutline(true));
   }
 
   return bReturn;

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -26,6 +26,11 @@
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
 
+namespace PVR
+{
+  class CGUIWindowPVRGuide;
+}
+
 namespace EPG
 {
   #define MAXCHANNELS 20
@@ -40,6 +45,8 @@ namespace EPG
 
   class CGUIEPGGridContainer : public CGUIControl
   {
+  friend class PVR::CGUIWindowPVRGuide;
+
   public:
     CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width, float height,
                          ORIENTATION orientation, int scrollTime, int preloadItems, int minutesPerPage,

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -214,6 +214,8 @@ bool CGUIEditControl::OnAction(const CAction &action)
       }
     default:
       {
+        if (m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW)
+          return false;
         ClearMD5();
         m_text2.insert(m_text2.begin() + m_cursorPos++, (WCHAR)action.GetUnicode());
         break;
@@ -224,6 +226,8 @@ bool CGUIEditControl::OnAction(const CAction &action)
   }
   else if (action.GetID() >= REMOTE_0 && action.GetID() <= REMOTE_9)
   { // input from the remote
+    if (m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW)
+      return false;
     ClearMD5();
     if (m_inputType == INPUT_TYPE_FILTER)
     { // filtering - use single number presses
@@ -294,6 +298,9 @@ void CGUIEditControl::OnClick()
       break;
     case INPUT_TYPE_FILTER:
       textChanged = CGUIDialogKeyboard::ShowAndGetFilter(utf8, false);
+      break;
+    case INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW:
+      textChanged = CGUIDialogNumeric::ShowAndVerifyNewPassword(utf8);
       break;
     case INPUT_TYPE_PASSWORD_MD5:
       utf8 = ""; // TODO: Ideally we'd send this to the keyboard and tell the keyboard we have this type of input
@@ -448,7 +455,7 @@ void CGUIEditControl::SetHint(const CGUIInfoLabel& hint)
 
 CStdStringW CGUIEditControl::GetDisplayedText() const
 {
-  if (m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5)
+  if (m_inputType == INPUT_TYPE_PASSWORD || m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW)
   {
     CStdStringW text;
     text.append(m_text2.size(), L'*');
@@ -475,7 +482,7 @@ void CGUIEditControl::SetLabel2(const std::string &text)
   g_charsetConverter.utf8ToW(text, newText);
   if (newText != m_text2)
   {
-    m_isMD5 = m_inputType == INPUT_TYPE_PASSWORD_MD5;
+    m_isMD5 = (m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW);
     m_text2 = newText;
     m_cursorPos = m_text2.size();
     SetInvalid();
@@ -493,12 +500,13 @@ CStdString CGUIEditControl::GetLabel2() const
 
 bool CGUIEditControl::ClearMD5()
 {
-  if (m_inputType != INPUT_TYPE_PASSWORD_MD5 || !m_isMD5)
+  if (!(m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW) || !m_isMD5)
     return false;
   
   m_text2.Empty();
   m_cursorPos = 0;
-  m_isMD5 = false;
+  if (m_inputType != INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW)
+    m_isMD5 = false;
   return true;
 }
 

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -50,7 +50,8 @@ public:
                     INPUT_TYPE_PASSWORD,
                     INPUT_TYPE_PASSWORD_MD5,
                     INPUT_TYPE_SEARCH,
-                    INPUT_TYPE_FILTER
+                    INPUT_TYPE_FILTER,
+                    INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW
                   };
 
   CGUIEditControl(int parentID, int controlID, float posX, float posY,

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -68,6 +68,7 @@ bool CPVRDatabase::CreateTables()
           "bIsRadio             bool, "
           "bIsHidden            bool, "
           "bIsUserSetIcon       bool, "
+          "bIsLocked            bool, "
           "sIconPath            varchar(255), "
           "sChannelName         varchar(64), "
           "bIsVirtual           bool, "
@@ -260,6 +261,9 @@ bool CPVRDatabase::UpdateOldVersion(int iVersion)
 
       if (iVersion < 21)
         m_pDS->exec("ALTER TABLE channelgroups ADD iGroupType integer");
+
+      if (iVersion < 22)
+        m_pDS->exec("ALTER TABLE channels ADD bIsLocked bool");
     }
   }
   catch (...)
@@ -332,7 +336,7 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
   int iReturn(0);
 
   CStdString strQuery = FormatSQL("SELECT channels.idChannel, channels.iUniqueId, channels.bIsRadio, channels.bIsHidden, channels.bIsUserSetIcon, "
-      "channels.sIconPath, channels.sChannelName, channels.bIsVirtual, channels.bEPGEnabled, channels.sEPGScraper, channels.iLastWatched, channels.iClientId, "
+      "channels.sIconPath, channels.sChannelName, channels.bIsVirtual, channels.bEPGEnabled, channels.sEPGScraper, channels.iLastWatched, channels.iClientId, channels.bIsLocked, "
       "channels.iClientChannelNumber, channels.sInputFormat, channels.sInputFormat, channels.sStreamURL, channels.iEncryptionSystem, map_channelgroups_channels.iChannelNumber, channels.idEpg "
       "FROM map_channelgroups_channels "
       "LEFT JOIN channels ON channels.idChannel = map_channelgroups_channels.idChannel "
@@ -350,6 +354,7 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results)
         channel->m_bIsRadio                = m_pDS->fv("bIsRadio").get_asBool();
         channel->m_bIsHidden               = m_pDS->fv("bIsHidden").get_asBool();
         channel->m_bIsUserSetIcon          = m_pDS->fv("bIsUserSetIcon").get_asBool();
+        channel->m_bIsLocked               = m_pDS->fv("bIsLocked").get_asBool();
         channel->m_strIconPath             = m_pDS->fv("sIconPath").get_asString();
         channel->m_strChannelName          = m_pDS->fv("sChannelName").get_asString();
         channel->m_bIsVirtual              = m_pDS->fv("bIsVirtual").get_asBool();
@@ -895,11 +900,11 @@ bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
   {
     /* new channel */
     strQuery = FormatSQL("INSERT INTO channels ("
-        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, "
+        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsLocked, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idEpg) "
-        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i)",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0),
+        "VALUES (%i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i)",
+        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(),
         channel.EpgID());
@@ -908,11 +913,11 @@ bool CPVRDatabase::Persist(CPVRChannel &channel, bool bQueueWrite /* = false */)
   {
     /* update channel */
     strQuery = FormatSQL("REPLACE INTO channels ("
-        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, "
+        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsLocked, "
         "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
         "iClientChannelNumber, sInputFormat, sStreamURL, iEncryptionSystem, idChannel, idEpg) "
-        "VALUES (%i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i)",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0),
+        "VALUES (%i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, '%s', '%s', %i, %i, %i)",
+        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), (channel.IsVirtual() ? 1 : 0), (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.ClientChannelNumber(), channel.InputFormat().c_str(), channel.StreamURL().c_str(), channel.EncryptionSystem(), channel.ChannelID(),
         channel.EpgID());

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -60,7 +60,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetMinVersion() const { return 21; };
+    virtual int GetMinVersion() const { return 22; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -26,6 +26,7 @@
 #include "threads/Event.h"
 #include "windows/GUIWindowPVRCommon.h"
 #include "addons/include/xbmc_pvr_types.h"
+#include "utils/Stopwatch.h"
 
 class CGUIDialogExtendedProgressBar;
 
@@ -423,6 +424,27 @@ namespace PVR
      */
     void LoadCurrentChannelSettings(void);
 
+    /*!
+     * @brief Check if channel is parental locked. Ask for PIN if neccessary.
+     * @param channel The channel to open.
+     * @return True if channel is unlocked (by default or PIN unlocked), false otherwise.
+     */
+    bool CheckParentalLock(const CPVRChannel *channel);
+
+    /*!
+     * @brief Check if parental lock is overriden at the given moment.
+     * @param channel The channel to open.
+     * @return True if parental lock is overriden, false otherwise.
+     */
+    bool CheckParentalOverride(const CPVRChannel *channel);
+
+    /*!
+     * @brief Open Numeric dialog to check for parental PIN.
+     * @param bool bSettings is true if this is called from settins, false otherwise.
+     * @return True if entered PIN was correct, false otherwise.
+     */
+    bool CheckParentalPIN(bool bSettings = false);
+
   protected:
     /*!
      * @brief PVR update and control thread.
@@ -541,6 +563,7 @@ namespace PVR
 
     CCriticalSection                m_managerStateMutex;
     ManagerState                    m_managerState;
+    CStopWatch                      m_parentalTimer;
   };
 
   class CPVRRecordingsUpdateJob : public CJob

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -62,6 +62,7 @@ CPVRChannel::CPVRChannel(bool bRadio /* = false */)
   m_bIsRadio                = bRadio;
   m_bIsHidden               = false;
   m_bIsUserSetIcon          = false;
+  m_bIsLocked               = false;
   m_strIconPath             = StringUtils::EmptyString;
   m_strChannelName          = StringUtils::EmptyString;
   m_bIsVirtual              = false;
@@ -90,6 +91,7 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL &channel, unsigned int iClientId)
   m_bIsRadio                = channel.bIsRadio;
   m_bIsHidden               = channel.bIsHidden;
   m_bIsUserSetIcon          = false;
+  m_bIsLocked               = false;
   m_strIconPath             = channel.strIconPath;
   m_strChannelName          = channel.strChannelName;
   m_iUniqueId               = channel.iUniqueId;
@@ -126,6 +128,7 @@ CPVRChannel &CPVRChannel::operator=(const CPVRChannel &channel)
   m_bIsRadio                = channel.m_bIsRadio;
   m_bIsHidden               = channel.m_bIsHidden;
   m_bIsUserSetIcon          = channel.m_bIsUserSetIcon;
+  m_bIsLocked               = channel.m_bIsLocked;
   m_strIconPath             = channel.m_strIconPath;
   m_strChannelName          = channel.m_strChannelName;
   m_bIsVirtual              = channel.m_bIsVirtual;
@@ -277,6 +280,29 @@ bool CPVRChannel::SetHidden(bool bIsHidden, bool bSaveInDb /* = false */)
 
   return bReturn;
 }
+
+bool CPVRChannel::SetLocked(bool bIsLocked, bool bSaveInDb /* = false */)
+{
+  bool bReturn(false);
+  CSingleLock lock(m_critSection);
+
+  if (m_bIsLocked != bIsLocked)
+  {
+    /* update the locked flag */
+    m_bIsLocked = bIsLocked;
+    SetChanged();
+    m_bChanged = true;
+
+    /* persist the changes */
+    if (bSaveInDb)
+      Persist();
+
+    bReturn = true;
+  }
+
+  return bReturn;
+}
+
 
 bool CPVRChannel::IsRecording(void) const
 {

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -59,6 +59,7 @@ namespace PVR
     bool             m_bIsRadio;                /*!< true if this channel is a radio channel, false if not */
     bool             m_bIsHidden;               /*!< true if this channel is hidden, false if not */
     bool             m_bIsUserSetIcon;          /*!< true if user set the icon via GUI, false if not */
+    bool             m_bIsLocked;               /*!< true if channel is locked, false if not */
     CStdString       m_strIconPath;             /*!< the path to the icon for this channel */
     CStdString       m_strChannelName;          /*!< the name for this channel used by XBMC */
     bool             m_bIsVirtual;              /*!< true if this channel is marked as virtual, false if not */
@@ -170,6 +171,23 @@ namespace PVR
      * @return True if the something changed, false otherwise.
      */
     bool SetHidden(bool bIsHidden, bool bSaveInDb = false);
+
+    /*!
+     * @brief True if this channel is locked. False if not.
+     * @return True if this channel is locked. False if not.
+     */
+    bool IsLocked(void) const { return m_bIsLocked; }
+
+    /*!
+     * @brief Set to true to lock this channel. Set to false to unlock it.
+     *
+     * Set to true to lock this channel. Set to false to unlock it.
+     * Locked channels need can only be viewed if parental PIN entered.
+     * @param bIsLocked The new setting.
+     * @param bSaveInDb Save in the database or not.
+     * @return True if the something changed, false otherwise.
+     */
+    bool SetLocked(bool bIsLocked, bool bSaveInDb = false);
 
     /*!
      * @brief True if a recording is currently running on this channel. False if not.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -50,6 +50,7 @@
 #define IMAGE_CHANNEL_LOGO        10
 #define RADIOBUTTON_USEEPG        12
 #define SPIN_EPGSOURCE_SELECTION  13
+#define RADIOBUTTON_PARENTAL_LOCK 14
 #define CONTROL_LIST_CHANNELS     20
 #define BUTTON_GROUP_MANAGER      30
 #define BUTTON_EDIT_CHANNEL       31
@@ -253,6 +254,33 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioActive(CGUIMessage &message)
     {
       pItem->SetProperty("Changed", true);
       pItem->SetProperty("ActiveChannel", pRadioButton->IsSelected());
+      m_bContainsChanges = true;
+      Renumber();
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool CGUIDialogPVRChannelManager::OnClickButtonRadioParentalLocked(CGUIMessage &message)
+{
+  CGUIRadioButtonControl *pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_PARENTAL_LOCK);
+
+  // ask for PIN first
+  if (!g_PVRManager.CheckParentalPIN(true)) 
+  {
+    pRadioButton->SetSelected(!pRadioButton->IsSelected());
+    return false;
+  }
+
+  if (pRadioButton)
+  {
+    CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
+    if (pItem)
+    {
+      pItem->SetProperty("Changed", true);
+      pItem->SetProperty("ParentalLocked", pRadioButton->IsSelected());
       m_bContainsChanges = true;
       Renumber();
       return true;
@@ -496,6 +524,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel(CGUIMessage &message)
             channel->SetProperty("Icon", newchannel->IconPath());
             channel->SetProperty("EPGSource", (int)0);
             channel->SetProperty("ClientName", g_localizeStrings.Get(19209));
+            channel->SetProperty("ParentalLocked", false);
 
             m_channelItems->AddFront(channel, m_iSelected);
             m_viewControl.SetItems(*m_channelItems);
@@ -529,6 +558,8 @@ bool CGUIDialogPVRChannelManager::OnMessageClick(CGUIMessage &message)
     return OnClickButtonRadioTV(message);
   case RADIOBUTTON_ACTIVE:
     return OnClickButtonRadioActive(message);
+  case RADIOBUTTON_PARENTAL_LOCK:
+    return OnClickButtonRadioParentalLocked(message);
   case EDIT_NAME:
     return OnClickButtonEditName(message);
   case BUTTON_CHANNEL_LOGO:
@@ -667,6 +698,9 @@ void CGUIDialogPVRChannelManager::SetData(int iItem)
 
   pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_USEEPG);
   if (pRadioButton) pRadioButton->SetSelected(pItem->GetProperty("UseEPG").asBoolean());
+
+  pRadioButton = (CGUIRadioButtonControl *)GetControl(RADIOBUTTON_PARENTAL_LOCK);
+  if (pRadioButton) pRadioButton->SetSelected(pItem->GetProperty("ParentalLocked").asBoolean());
 }
 
 void CGUIDialogPVRChannelManager::Update()
@@ -693,6 +727,7 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty("UseEPG", channel->EPGEnabled());
     channelFile->SetProperty("Icon", channel->IconPath());
     channelFile->SetProperty("EPGSource", (int)0);
+    channelFile->SetProperty("ParentalLocked", channel->IsLocked());
     CStdString number; number.Format("%i", channel->ChannelNumber());
     channelFile->SetProperty("Number", number);
 
@@ -747,6 +782,7 @@ bool CGUIDialogPVRChannelManager::PersistChannel(CFileItemPtr pItem, CPVRChannel
   bool bHidden              = !pItem->GetProperty("ActiveChannel").asBoolean();
   bool bVirtual             = pItem->GetProperty("Virtual").asBoolean();
   bool bEPGEnabled          = pItem->GetProperty("UseEPG").asBoolean();
+  bool bParentalLocked      = pItem->GetProperty("ParentalLocked").asBoolean();
   int iEPGSource            = pItem->GetProperty("EPGSource").asInteger();
   CStdString strChannelName = pItem->GetProperty("Name").asString();
   CStdString strIconPath    = pItem->GetProperty("Icon").asString();
@@ -754,6 +790,7 @@ bool CGUIDialogPVRChannelManager::PersistChannel(CFileItemPtr pItem, CPVRChannel
 
   channel->SetChannelName(strChannelName);
   channel->SetHidden(bHidden);
+  channel->SetLocked(bParentalLocked);
   channel->SetIconPath(strIconPath);
   if (bVirtual)
     channel->SetStreamURL(strStreamURL);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -56,6 +56,7 @@ namespace PVR
     virtual bool OnClickButtonCancel(CGUIMessage &message);
     virtual bool OnClickButtonRadioTV(CGUIMessage &message);
     virtual bool OnClickButtonRadioActive(CGUIMessage &message);
+    virtual bool OnClickButtonRadioParentalLocked(CGUIMessage &message);
     virtual bool OnClickButtonEditName(CGUIMessage &message);
     virtual bool OnClickButtonChannelLogo(CGUIMessage &message);
     virtual bool OnClickButtonUseEPG(CGUIMessage &message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -33,6 +33,7 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "epg/Epg.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 
 using namespace std;
 using namespace PVR;
@@ -163,6 +164,10 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
 
   if (g_PVRManager.IsPlaying() && pItem->HasPVRChannelInfoTag() && g_application.m_pPlayer)
   {
+    CPVRChannel *channel = pItem->GetPVRChannelInfoTag();
+    if (!g_PVRManager.CheckParentalLock(channel))
+      return;
+
     if (!g_application.m_pPlayer->SwitchChannel(*pItem->GetPVRChannelInfoTag()))
     {
       Close(true);
@@ -183,9 +188,13 @@ void CGUIDialogPVRChannelsOSD::ShowInfo(int item)
   CFileItemPtr pItem = m_vecItems->Get(item);
   if (pItem && pItem->IsPVRChannel())
   {
+    CPVRChannel *channel = pItem->GetPVRChannelInfoTag();
+    if (!g_PVRManager.CheckParentalLock(channel))
+      return;
+
     /* Get the current running show on this channel from the EPG storage */
     CEpgInfoTag epgnow;
-    if (!pItem->GetPVRChannelInfoTag()->GetEPGNow(epgnow))
+    if (!channel->GetEPGNow(epgnow))
       return;
     CFileItem *itemNow  = new CFileItem(epgnow);
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -112,6 +112,9 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
     if (g_PVRClients->HasMenuHooks(pItem->GetPVRChannelInfoTag()->ClientID()))
       buttons.Add(CONTEXT_BUTTON_MENU_HOOKS, 19195);                                  /* PVR client specific action */
 
+    CPVRChannel *channel = pItem->GetPVRChannelInfoTag();
+    buttons.Add(CONTEXT_BUTTON_ADD_LOCK, channel->IsLocked() ? 19258 : 19257);        /* show lock/unlock channel */
+
     buttons.Add(CONTEXT_BUTTON_FILTER, 19249);                                        /* filter channels */
     buttons.Add(CONTEXT_BUTTON_UPDATE_EPG, 19251);                                    /* update EPG information */
   }
@@ -134,6 +137,7 @@ bool CGUIWindowPVRChannels::OnContextButton(int itemNumber, CONTEXT_BUTTON butto
       OnContextButtonFilter(pItem.get(), button) ||
       OnContextButtonUpdateEpg(pItem.get(), button) ||
       OnContextButtonRecord(pItem.get(), button) ||
+      OnContextButtonLock(pItem.get(), button) ||
       CGUIWindowPVRCommon::OnContextButton(itemNumber, button);
 }
 
@@ -352,6 +356,38 @@ bool CGUIWindowPVRChannels::OnContextButtonHide(CFileItem *item, CONTEXT_BUTTON 
       return bReturn;
 
     g_PVRManager.GetPlayingGroup(m_bRadio)->RemoveFromGroup(*channel);
+    UpdateData();
+
+    bReturn = true;
+  }
+
+  return bReturn;
+}
+
+bool CGUIWindowPVRChannels::OnContextButtonLock(CFileItem *item, CONTEXT_BUTTON button)
+{
+  bool bReturn = false;
+
+  if (button == CONTEXT_BUTTON_ADD_LOCK)
+  {
+    // ask for PIN first
+    if (!g_PVRManager.CheckParentalPIN(true))
+      return bReturn;
+
+    CPVRChannelGroup *group = g_PVRChannelGroups->GetGroupAll(m_bRadio);
+    if (!group)
+      return bReturn;
+
+    // Get the REAL channel!!!
+    CPVRChannel *channel = (CPVRChannel *) group->GetByUniqueID(item->GetPVRChannelInfoTag()->UniqueID());
+    if (!channel)
+      return bReturn;
+
+    if(channel->IsLocked())
+      channel->SetLocked(false, true);
+    else
+      channel->SetLocked(true, true);
+
     UpdateData();
 
     bReturn = true;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -64,6 +64,7 @@ namespace PVR
     virtual bool OnContextButtonFilter(CFileItem *item, CONTEXT_BUTTON button);
     virtual bool OnContextButtonUpdateEpg(CFileItem *item, CONTEXT_BUTTON button);
     virtual bool OnContextButtonRecord(CFileItem *item, CONTEXT_BUTTON button);
+    virtual bool OnContextButtonLock(CFileItem *item, CONTEXT_BUTTON button);
 
     virtual void ShowGroupManager(void);
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -219,7 +219,7 @@ void CGUIWindowPVRGuide::UpdateViewTimeline(void)
   m_parent->m_vecItems->RemoveDiscCache(m_parent->GetID());
 
   m_parent->m_guideGrid->SetStartEnd(firstDate > gridStart ? firstDate : gridStart, lastDate);
-  m_parent->m_viewControl.SetCurrentView(CONTROL_LIST_TIMELINE);
+  m_parent->m_viewControl.SetCurrentView(CONTROL_LIST_TIMELINE, true);
   SelectPlayingFile();
 }
 
@@ -395,6 +395,9 @@ bool CGUIWindowPVRGuide::PlayEpgItem(CFileItem *item)
   const CPVRChannel *channel = !item || !item->HasEPGInfoTag() || !item->GetEPGInfoTag()->HasPVRChannel() ?
       NULL : item->GetEPGInfoTag()->ChannelTag();
   if (!channel)
+    return false;
+
+  if (!g_PVRManager.CheckParentalLock(channel))
     return false;
 
   CLog::Log(LOGDEBUG, "play channel '%s'", channel->ChannelName().c_str());

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -957,6 +957,12 @@ void CGUISettings::Initialize()
   AddSeparator(pvrpwr, "pvrpowermanagement.sep2");
   AddBool(pvrpwr, "pvrpowermanagement.dailywakeup", 19247, false);
   AddString(pvrpwr, "pvrpowermanagement.dailywakeuptime", 19248, "00:00:00", EDIT_CONTROL_INPUT);
+
+  CSettingsCategory* pvrpa = AddCategory(8, "pvrparental", 19259);
+  AddBool(pvrpa, "pvrparental.enabled", 449  , false);
+  AddSeparator(pvrpa, "pvrparental.sep1");
+  AddString(pvrpa, "pvrparental.pin", 19261, "", EDIT_CONTROL_HIDDEN_NUMBER_VERIFY_NEW, true);
+  AddInt(pvrpa, "pvrparental.duration", 19260, 300, 5, 5, 1200, SPIN_CONTROL_INT_PLUS, MASK_SECS);
 }
 
 CGUISettings::~CGUISettings(void)

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -149,20 +149,21 @@ class TiXmlElement;
 #define SETTINGS_TYPE_PATH      7
 #define SETTINGS_TYPE_ADDON     8
 
-#define CHECKMARK_CONTROL           1
-#define SPIN_CONTROL_FLOAT          2
-#define SPIN_CONTROL_INT            3
-#define SPIN_CONTROL_INT_PLUS       4
-#define SPIN_CONTROL_TEXT           5
-#define EDIT_CONTROL_INPUT          6
-#define EDIT_CONTROL_HIDDEN_INPUT   7
-#define EDIT_CONTROL_NUMBER_INPUT   8
-#define EDIT_CONTROL_IP_INPUT       9
-#define EDIT_CONTROL_MD5_INPUT     10
-#define BUTTON_CONTROL_STANDARD    11
-#define BUTTON_CONTROL_MISC_INPUT  12
-#define BUTTON_CONTROL_PATH_INPUT  13
-#define SEPARATOR_CONTROL          14
+#define CHECKMARK_CONTROL                      1
+#define SPIN_CONTROL_FLOAT                     2
+#define SPIN_CONTROL_INT                       3
+#define SPIN_CONTROL_INT_PLUS                  4
+#define SPIN_CONTROL_TEXT                      5
+#define EDIT_CONTROL_INPUT                     6
+#define EDIT_CONTROL_HIDDEN_INPUT              7
+#define EDIT_CONTROL_NUMBER_INPUT              8
+#define EDIT_CONTROL_IP_INPUT                  9
+#define EDIT_CONTROL_MD5_INPUT                10
+#define BUTTON_CONTROL_STANDARD               11
+#define BUTTON_CONTROL_MISC_INPUT             12
+#define BUTTON_CONTROL_PATH_INPUT             13
+#define SEPARATOR_CONTROL                     14
+#define EDIT_CONTROL_HIDDEN_NUMBER_VERIFY_NEW 15
 
 #define REPLAY_GAIN_NONE 0
 #define REPLAY_GAIN_ALBUM 1

--- a/xbmc/settings/SettingsControls.cpp
+++ b/xbmc/settings/SettingsControls.cpp
@@ -196,6 +196,8 @@ CEditSettingControl::CEditSettingControl(CGUIEditControl *pEdit, int id, CSettin
     m_pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_IPADDRESS, heading);
   else if (pSetting->GetControlType() == EDIT_CONTROL_NUMBER_INPUT)
     m_pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_NUMBER, heading);
+  else if (pSetting->GetControlType() == EDIT_CONTROL_HIDDEN_NUMBER_VERIFY_NEW)
+    m_pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW, heading);
   else
     m_pEdit->SetInputType(CGUIEditControl::INPUT_TYPE_TEXT, heading);
   Update();

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -21,9 +21,15 @@
 
 #include "GUIDialogVideoOSD.h"
 #include "Application.h"
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/MouseStat.h"
+
+#include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
+
+using namespace PVR;
 
 CGUIDialogVideoOSD::CGUIDialogVideoOSD(void)
     : CGUIDialog(WINDOW_DIALOG_VIDEO_OSD, "VideoOSD.xml")
@@ -57,6 +63,21 @@ bool CGUIDialogVideoOSD::OnAction(const CAction &action)
   if (action.GetID() == ACTION_NEXT_ITEM || action.GetID() == ACTION_PREV_ITEM)
   {
     // these could indicate next chapter if video supports it
+    if (g_application.CurrentFileItem().IsLiveTV())
+    {
+      CPVRChannel playingChannel, *nextChannel;
+      g_PVRManager.GetCurrentChannel(playingChannel);
+  
+      CPVRChannelGroup *selectedGroup = g_PVRManager.GetPlayingGroup(playingChannel.IsRadio());
+  
+      if (action.GetID() == ACTION_NEXT_ITEM)
+        nextChannel = selectedGroup->GetByChannelUp(playingChannel);
+      else
+        nextChannel = selectedGroup->GetByChannelDown(playingChannel);
+
+      if (!g_PVRManager.CheckParentalLock(nextChannel))
+        return true;
+    }
     if (g_application.m_pPlayer != NULL && g_application.m_pPlayer->OnAction(action))
       return true;
   }


### PR DESCRIPTION
This adds parental control for PVR channels and EPG. Channels can be locked/unlocked from the channels window and channel manager. The EPG of locked channels is also locked (this way unauthorized users won't be able to see indecent EPG titles/plots and/or schedule recordings). Parental control can be enabled/disabled in the live tv section of the settings.

I tried to be as minimal invasive as possible by keeping user experience in my mind. I didn't want to lock the player thead so I chose to implement the parental checks in the GUI section, which includes quite a few files. I hope that I didn't miss anything.
