### PR TITLE
pvr: Mark recordings 'watched' / 'unwatched'

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -201,6 +201,14 @@ extern "C"
    */
   PVR_ERROR RenameRecording(const PVR_RECORDING &recording);
 
+  /*!
+   * @brief Set the play count of a recording on the backend.
+   * @param recording The recording to change the play count.
+   * @param count Play count.
+   * @return PVR_ERROR_NO_ERROR if the recording's play count has been set successfully.
+   */
+  PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count);
+
   //@}
   /** @name PVR timer methods */
   //@{
@@ -406,6 +414,7 @@ extern "C"
     pClient->GetRecordings           = GetRecordings;
     pClient->DeleteRecording         = DeleteRecording;
     pClient->RenameRecording         = RenameRecording;
+    pClient->SetRecordingPlayCount   = SetRecordingPlayCount;
 
     pClient->GetTimersAmount         = GetTimersAmount;
     pClient->GetTimers               = GetTimers;

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -158,6 +158,7 @@ extern "C" {
     bool bHandlesInputStream;           /*!< @brief (optional) true if this add-on provides an input stream. false if XBMC handles the stream. */
     bool bHandlesDemuxing;              /*!< @brief (optional) true if this add-on demultiplexes packets. */
     bool bSupportsRecordingFolders;     /*!< @brief (optional) true if the backend supports timers / recordings in folders. */
+    bool bSupportsRecordingPlayCount;   /*!< @brief (optional) true if the backend supports play count for recordings. */
   } ATTRIBUTE_PACKED PVR_ADDON_CAPABILITIES;
 
   /*!
@@ -310,6 +311,7 @@ extern "C" {
     int           iLifetime;            /*!< @brief (optional) life time in days of this recording */
     int           iGenreType;           /*!< @brief (optional) genre type */
     int           iGenreSubType;        /*!< @brief (optional) genre sub type */
+    bool          iPlayCount;           /*!< @brief (optional) play count of this recording on the client */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!
@@ -358,6 +360,7 @@ extern "C" {
     PVR_ERROR    (__cdecl* GetRecordings)(PVR_HANDLE handle);
     PVR_ERROR    (__cdecl* DeleteRecording)(const PVR_RECORDING &recording);
     PVR_ERROR    (__cdecl* RenameRecording)(const PVR_RECORDING &recording);
+    PVR_ERROR    (__cdecl* SetRecordingPlayCount)(const PVR_RECORDING &recording, int count);
     //@}
 
     /** @name PVR timer methods */

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -85,18 +85,19 @@ void CPVRClient::ResetProperties(void)
 
 void CPVRClient::ResetAddonCapabilities(void)
 {
-  m_addonCapabilities.bSupportsChannelSettings  = false;
-  m_addonCapabilities.bSupportsTimeshift        = false;
-  m_addonCapabilities.bSupportsEPG              = false;
-  m_addonCapabilities.bSupportsTV               = false;
-  m_addonCapabilities.bSupportsRadio            = false;
-  m_addonCapabilities.bSupportsRecordings       = false;
-  m_addonCapabilities.bSupportsTimers           = false;
-  m_addonCapabilities.bSupportsChannelGroups    = false;
-  m_addonCapabilities.bSupportsChannelScan      = false;
-  m_addonCapabilities.bHandlesInputStream       = false;
-  m_addonCapabilities.bHandlesDemuxing          = false;
-  m_addonCapabilities.bSupportsRecordingFolders = false;
+  m_addonCapabilities.bSupportsChannelSettings    = false;
+  m_addonCapabilities.bSupportsTimeshift          = false;
+  m_addonCapabilities.bSupportsEPG                = false;
+  m_addonCapabilities.bSupportsTV                 = false;
+  m_addonCapabilities.bSupportsRadio              = false;
+  m_addonCapabilities.bSupportsRecordings         = false;
+  m_addonCapabilities.bSupportsTimers             = false;
+  m_addonCapabilities.bSupportsChannelGroups      = false;
+  m_addonCapabilities.bSupportsChannelScan        = false;
+  m_addonCapabilities.bHandlesInputStream         = false;
+  m_addonCapabilities.bHandlesDemuxing            = false;
+  m_addonCapabilities.bSupportsRecordingFolders   = false;
+  m_addonCapabilities.bSupportsRecordingPlayCount = false;
 }
 
 bool CPVRClient::Create(int iClientId)
@@ -626,6 +627,33 @@ PVR_ERROR CPVRClient::RenameRecording(const CPVRRecording &recording)
   catch (exception &e)
   {
     CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call RenameRecording() on addon '%s'. please contact the developer of this addon: %s",
+        __FUNCTION__, e.what(), GetFriendlyName().c_str(), Author().c_str());
+  }
+
+  return retVal;
+}
+
+PVR_ERROR CPVRClient::SetRecordingPlayCount(const CPVRRecording &recording, int count)
+{
+  PVR_ERROR retVal = PVR_ERROR_UNKNOWN;
+  if (!m_bReadyToUse)
+    return retVal;
+
+  if (!m_addonCapabilities.bSupportsRecordingPlayCount)
+    return PVR_ERROR_NOT_IMPLEMENTED;
+
+  try
+  {
+    PVR_RECORDING tag;
+    PVRWriteClientRecordingInfo(recording, tag);
+
+    retVal = m_pStruct->SetRecordingPlayCount(tag, count);
+
+    LogError(retVal, __FUNCTION__);
+  }
+  catch (exception &e)
+  {
+    CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call SetRecordingPlayCount() on addon '%s'. please contact the developer of this addon: %s",
         __FUNCTION__, e.what(), GetFriendlyName().c_str(), Author().c_str());
   }
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -256,6 +256,14 @@ namespace PVR
      */
     PVR_ERROR RenameRecording(const CPVRRecording &recording);
 
+    /*!
+     * @brief Set the play count of a recording on the backend.
+     * @param recording The recording to set the play count.
+     * @param count Play count.
+     * @return PVR_ERROR_NO_ERROR if the recording's play count has been set successfully.
+     */
+    PVR_ERROR SetRecordingPlayCount(const CPVRRecording &recording, int count);
+
     //@}
     /** @name PVR timer methods */
     //@{

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -798,6 +798,18 @@ bool CPVRClients::DeleteRecording(const CPVRRecording &recording, PVR_ERROR *err
   return *error == PVR_ERROR_NO_ERROR;
 }
 
+bool CPVRClients::SetRecordingPlayCount(const CPVRRecording &recording, int count, PVR_ERROR *error)
+{
+  *error = PVR_ERROR_UNKNOWN;
+  boost::shared_ptr<CPVRClient> client;
+  if (GetConnectedClient(recording.m_iClientId, client) && client->GetAddonCapabilities().bSupportsRecordingPlayCount)
+    *error = client->SetRecordingPlayCount(recording, count);
+  else
+    CLog::Log(LOGERROR, "PVR - %s - client %d does not support setting recording's play count",__FUNCTION__, recording.m_iClientId);
+
+  return *error == PVR_ERROR_NO_ERROR;
+}
+
 bool CPVRClients::IsRecordingOnPlayingChannel(void) const
 {
   CPVRChannel currentChannel;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -465,6 +465,15 @@ namespace PVR
     bool DeleteRecording(const CPVRRecording &recording, PVR_ERROR *error);
 
     /*!
+     * @brief Set play count of a recording on the backend.
+     * @param recording The recording to set the play count.
+     * @param count Play count.
+     * @param error An error if it occured.
+     * @return True if the recording's play count was set successfully, false otherwise.
+     */
+    bool SetRecordingPlayCount(const CPVRRecording &recording, int count, PVR_ERROR *error);
+
+    /*!
      * @brief Check whether there is an active recording on the current channel.
      * @return True if there is, false otherwise.
      */

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -53,6 +53,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   m_strStreamURL   = recording.strStreamURL;
   m_strChannelName = recording.strChannelName;
   m_genre          = StringUtils::Split(CEpg::ConvertGenreIdToString(recording.iGenreType, recording.iGenreSubType), g_advancedSettings.m_videoItemSeparator);
+  m_iRecPlayCount  = recording.iPlayCount;
 }
 
 bool CPVRRecording::operator ==(const CPVRRecording& right) const
@@ -70,7 +71,8 @@ bool CPVRRecording::operator ==(const CPVRRecording& right) const
        m_iLifetime          == right.m_iLifetime &&
        m_strDirectory       == right.m_strDirectory &&
        m_strFileNameAndPath == right.m_strFileNameAndPath &&
-       m_strTitle           == right.m_strTitle);
+       m_strTitle           == right.m_strTitle &&
+       m_iRecPlayCount      == right.m_iRecPlayCount);
 }
 
 bool CPVRRecording::operator !=(const CPVRRecording& right) const
@@ -88,6 +90,7 @@ void CPVRRecording::Reset(void)
   m_iPriority          = -1;
   m_iLifetime          = -1;
   m_strFileNameAndPath = StringUtils::EmptyString;
+  m_iRecPlayCount      = 0;
 
   m_recordingTime.Reset();
   CVideoInfoTag::Reset();
@@ -126,6 +129,19 @@ bool CPVRRecording::Rename(const CStdString &strNewName)
   return true;
 }
 
+bool CPVRRecording::SetPlayCount(int count)
+{
+  PVR_ERROR error;
+  m_iRecPlayCount = count;
+  if (!g_PVRClients->SetRecordingPlayCount(*this, count, &error))
+  {
+    DisplayError(error);
+    return false;
+  }
+
+  return true;
+}
+
 void CPVRRecording::DisplayError(PVR_ERROR err) const
 {
   if (err == PVR_ERROR_SERVER_ERROR)
@@ -155,6 +171,7 @@ void CPVRRecording::Update(const CPVRRecording &tag)
   m_strStreamURL   = tag.m_strStreamURL;
   m_strChannelName = tag.m_strChannelName;
   m_genre          = tag.m_genre;
+  m_iRecPlayCount  = tag.m_iRecPlayCount;
 
   CStdString strShow;
   strShow.Format("%s - ", g_localizeStrings.Get(20364).c_str());

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -53,6 +53,7 @@ namespace PVR
     int           m_iLifetime;      /*!< lifetime of this recording */
     CStdString    m_strStreamURL;   /*!< stream URL. if empty use pvr client */
     CStdString    m_strDirectory;   /*!< directory of this recording on the client */
+    bool          m_iRecPlayCount;  /*!< play count of this recording on the client */
 
     CPVRRecording(void);
     CPVRRecording(const PVR_RECORDING &recording, unsigned int iClientId);
@@ -84,6 +85,13 @@ namespace PVR
      * @return True if it was renamed successfully, false otherwise.
      */
     bool Rename(const CStdString &strNewName);
+
+    /*!
+     * @brief Set this recording's play count on the client (if supported).
+     * @param count play count.
+     * @return True if play count was set successfully, false otherwise.
+     */
+    bool SetPlayCount(int count);
 
     /*!
      * @brief Update this tag with the contents of the given tag.

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -63,6 +63,7 @@ namespace PVR
     int GetRecordings(CFileItemList* results);
     bool DeleteRecording(const CFileItem &item);
     bool RenameRecording(CFileItem &item, CStdString &strNewName);
+    bool SetRecordingsPlayCount(const CFileItemPtr &item, int count);
 
     bool GetDirectory(const CStdString& strPath, CFileItemList &items);
     CPVRRecording *GetByPath(const CStdString &path);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -93,6 +93,19 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
   {
     buttons.Add(CONTEXT_BUTTON_RESUME_ITEM, resumeString);
   }
+  if (pItem->m_bIsFolder)
+  {
+    // Have both options for folders since we don't know whether all childs are watched/unwatched
+    buttons.Add(CONTEXT_BUTTON_MARK_UNWATCHED, 16104); /* Mark as UnWatched */
+    buttons.Add(CONTEXT_BUTTON_MARK_WATCHED, 16103);   /* Mark as Watched */
+  }
+  if (pItem->HasPVRRecordingInfoTag())
+  {
+    if (pItem->GetPVRRecordingInfoTag()->m_playCount > 0)
+      buttons.Add(CONTEXT_BUTTON_MARK_UNWATCHED, 16104); /* Mark as UnWatched */
+    else
+      buttons.Add(CONTEXT_BUTTON_MARK_WATCHED, 16103);   /* Mark as Watched */
+  }
   buttons.Add(CONTEXT_BUTTON_RENAME, 118);      /* Rename this recording */
   buttons.Add(CONTEXT_BUTTON_DELETE, 117);      /* Delete this recording */
   buttons.Add(CONTEXT_BUTTON_SORTBY_NAME, 103);       /* sort by name */
@@ -137,6 +150,7 @@ bool CGUIWindowPVRRecordings::OnContextButton(int itemNumber, CONTEXT_BUTTON but
       OnContextButtonRename(pItem.get(), button) ||
       OnContextButtonDelete(pItem.get(), button) ||
       OnContextButtonInfo(pItem.get(), button) ||
+      OnContextButtonMarkWatched(pItem, button) ||
       CGUIWindowPVRCommon::OnContextButton(itemNumber, button);
 }
 
@@ -316,6 +330,33 @@ bool CGUIWindowPVRRecordings::OnContextButtonRename(CFileItem *item, CONTEXT_BUT
       if (g_PVRRecordings->RenameRecording(*item, strNewName))
         UpdateData();
     }
+  }
+
+  return bReturn;
+}
+
+bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &item, CONTEXT_BUTTON button)
+{
+  bool bReturn = false;
+
+  if (button == CONTEXT_BUTTON_MARK_WATCHED)
+  {
+    bReturn = true;
+
+    int newSelection = m_parent->m_viewControl.GetSelectedItem();
+    g_PVRRecordings->SetRecordingsPlayCount(item, 1);
+    m_parent->m_viewControl.SetSelectedItem(newSelection);
+
+    UpdateData();
+  }
+
+  if (button == CONTEXT_BUTTON_MARK_UNWATCHED)
+  {
+    bReturn = true;
+
+    g_PVRRecordings->SetRecordingsPlayCount(item, 0);
+
+    UpdateData();
   }
 
   return bReturn;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -56,6 +56,7 @@ namespace PVR
     virtual bool OnContextButtonInfo(CFileItem *item, CONTEXT_BUTTON button);
     virtual bool OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTON button);
     virtual bool OnContextButtonRename(CFileItem *item, CONTEXT_BUTTON button);
+    virtual bool OnContextButtonMarkWatched(const CFileItemPtr &item, CONTEXT_BUTTON button);
 
     CStdString m_strSelectedPath;
   };

--- a/xbmc/pvrclients/MediaPortal/client.cpp
+++ b/xbmc/pvrclients/MediaPortal/client.cpp
@@ -731,4 +731,6 @@ long long SeekLiveStream(long long pos, int whence) { return -1; }
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1 ; }
 
+PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
+
 } //end extern "C"

--- a/xbmc/pvrclients/mythtv/client.cpp
+++ b/xbmc/pvrclients/mythtv/client.cpp
@@ -478,5 +478,6 @@ long long SeekLiveStream(long long iPosition, int iWhence) { return -1; }
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channelinfo) { return ""; }
+PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
 
 } //end extern "C"

--- a/xbmc/pvrclients/pvr-demo/client.cpp
+++ b/xbmc/pvrclients/pvr-demo/client.cpp
@@ -280,6 +280,7 @@ int GetRecordingsAmount(void) { return -1; }
 PVR_ERROR GetRecordings(PVR_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(PVR_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -551,4 +551,5 @@ long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { re
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
+PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
 }

--- a/xbmc/pvrclients/vdr-vnsi/client.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/client.cpp
@@ -638,5 +638,6 @@ long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { re
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
+PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
 
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -53,12 +53,15 @@
 #include "ThumbnailCache.h"
 #include "utils/LabelFormatter.h"
 #include "XBDateTime.h"
+#include "pvr/PVRManager.h"
+#include "pvr/recordings/PVRRecordings.h"
 
 using namespace std;
 using namespace dbiplus;
 using namespace XFILE;
 using namespace VIDEO;
 using namespace ADDON;
+using namespace PVR;
 
 //********************************************************************************************************************************
 CVideoDatabase::CVideoDatabase(void)
@@ -3741,6 +3744,11 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
     }
 
     m_pDS->exec(strSQL.c_str());
+
+    // PVR: Set recording's play count on the backend (if supported)
+    if (item.HasPVRRecordingInfoTag() && g_PVRManager.IsStarted()) {
+      g_PVRRecordings->GetByPath(item.GetPath())->SetPlayCount(count);
+    }
 
     // We only need to announce changes to video items in the library
     if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId > 0)


### PR DESCRIPTION
This is my first contribution to the pvr branch, so please be patient :-)
Great that we have the recording's watched state visible in the recordings view.

This PR basically adds 2 new features --> watched/unwatched in context menu and client api to sync watched state 

2dbda19 Adds 'mark watched' / 'unwatched' to the recording's context menu that changes the watched state in the video database. Works for both, single files and complete folders. The code that is actually changing the values in the database has been taken from GUIWindowVideoBase::MarkWatched.

fc7452b Adds an client API function "MarkRecordingWatched". This allows to set the watched state on the client (if supported). For some clients like mythtv, this functionality is quite essential as it allows the backend to maintain the disk space better (watched recordings can be removed when running out of space). Another advantage is that you have a consistent view when using different frontend / webinterface with the backend.            

a89437b Uses the new client API to set the watched state on the client in video database SetPlayCount. This syncs the state with the client for example after watching a recording.

Looking forward to your comments! 
Christian

Updated this PR to also contain the API (cause that one depends on the context menu). Hope that is ok for you  
