### PR TITLE
epg: also update channel info on child epg infotags when updating epg table...

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -672,6 +672,13 @@ bool CEpg::UpdateMetadata(const CEpg &epg, bool bUpdateDb /* = false */)
   {
     m_iPVRChannelId     = epg.m_iPVRChannelId;
     m_iPVRChannelNumber = epg.m_iPVRChannelNumber;
+
+    /* Copy the new channel information to all child tags */
+    for (map<CDateTime, CEpgInfoTag *>::const_iterator it = m_tags.begin(); it != m_tags.end(); it++)
+    {
+      it->second->SetPVRChannelID(m_iPVRChannelId);
+      it->second->SetPVRChannelNumber(m_iPVRChannelNumber);
+    }
   }
 
   if (bUpdateDb)

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -785,6 +785,18 @@ CPVRTimerInfoTag *CEpgInfoTag::Timer(void) const
   return tag;
 }
 
+void CEpgInfoTag::SetPVRChannelID(int iPVRChannelID)
+{
+  CSingleLock lock(m_critSection);
+  m_iPVRChannelID = iPVRChannelID;
+}
+
+void CEpgInfoTag::SetPVRChannelNumber(int iPVRChannelNumber)
+{
+  CSingleLock lock(m_critSection);
+  m_iPVRChannelNumber = iPVRChannelNumber;
+}
+
 bool CEpgInfoTag::HasPVRChannel(void) const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -376,6 +376,18 @@ namespace EPG
     virtual PVR::CPVRTimerInfoTag *Timer(void) const;
 
     /*!
+     * @brief Set the PVR channel ID of the tag
+     * @param The new value
+     */
+    virtual void SetPVRChannelID(int iPVRChannelID);
+
+    /*!
+     * @brief Set the PVR channel number of the tag
+     * @param The new value
+     */
+    virtual void SetPVRChannelNumber(int iPVRChannelNumber);
+
+    /*!
      * @return True if this tag has a PVR channel set.
      */
     virtual bool HasPVRChannel(void) const;


### PR DESCRIPTION
...through UpdateMetadata method. Fixes missing channel info from epg infotags when epg is loaded from the db first and then updated by pvr manager.
