### PR TITLE
Don't delete groups added by the user with XBMC

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -106,7 +106,7 @@ bool CPVRDatabase::CreateTables()
         "CREATE TABLE channelgroups ("
           "idGroup         integer primary key,"
           "bIsRadio        bool, "
-          "bIsUserSetGroup bool, "
+          "iGroupType      integer, "
           "sName           varchar(64)"
         ")"
     );
@@ -259,7 +259,7 @@ bool CPVRDatabase::UpdateOldVersion(int iVersion)
         m_pDS->exec("ALTER TABLE channels ADD bIsUserSetIcon bool");
 
       if (iVersion < 21)
-        m_pDS->exec("ALTER TABLE channelgroups ADD bIsUserSetGroup bool");
+        m_pDS->exec("ALTER TABLE channelgroups ADD iGroupType integer");
     }
   }
   catch (...)
@@ -664,7 +664,7 @@ bool CPVRDatabase::Get(CPVRChannelGroups &results)
 
         data.SetGroupID(m_pDS->fv("idGroup").get_asInt());
         data.SetGroupName(m_pDS->fv("sName").get_asString());
-        data.SetUserSetGroup(m_pDS->fv("bIsUserSetGroup").get_asBool());
+        data.SetGroupType(m_pDS->fv("iGroupType").get_asInt());
 
         results.Update(data);
 
@@ -830,11 +830,11 @@ bool CPVRDatabase::Persist(CPVRChannelGroup &group)
 
     /* insert a new entry when this is a new group, or replace the existing one otherwise */
     if (group.GroupID() <= 0)
-      strQuery = FormatSQL("INSERT INTO channelgroups (bIsRadio, bIsUserSetGroup, sName) VALUES (%i, %i, '%s')",
-          (group.IsRadio() ? 1 :0), (group.IsUserSetGroup() ? 1 :0), group.GroupName().c_str());
+      strQuery = FormatSQL("INSERT INTO channelgroups (bIsRadio, iGroupType, sName) VALUES (%i, %i, '%s')",
+          (group.IsRadio() ? 1 :0), group.GroupType(), group.GroupName().c_str());
     else
-      strQuery = FormatSQL("REPLACE INTO channelgroups (idGroup, bIsRadio, bIsUserSetGroup, sName) VALUES (%i, %i, %i, '%s')",
-          group.GroupID(), (group.IsRadio() ? 1 :0), (group.IsUserSetGroup() ? 1 :0), group.GroupName().c_str());
+      strQuery = FormatSQL("REPLACE INTO channelgroups (idGroup, bIsRadio, iGroupType, sName) VALUES (%i, %i, %i, '%s')",
+          group.GroupID(), (group.IsRadio() ? 1 :0), group.GroupType(), group.GroupName().c_str());
 
     bReturn = ExecuteQuery(strQuery);
 

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -60,7 +60,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    virtual int GetMinVersion() const { return 20; };
+    virtual int GetMinVersion() const { return 21; };
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -44,7 +44,7 @@ using namespace EPG;
 
 CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const CStdString &strGroupName) :
     m_bRadio(bRadio),
-    m_bIsUserSetGroup(false),
+    m_iGroupType(PVR_GROUP_TYPE_DEFAULT),
     m_iGroupId(iGroupId),
     m_strGroupName(strGroupName),
     m_bLoaded(false),
@@ -55,7 +55,7 @@ CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const CSt
 
 CPVRChannelGroup::CPVRChannelGroup(bool bRadio) :
     m_bRadio(bRadio),
-    m_bIsUserSetGroup(false),
+    m_iGroupType(PVR_GROUP_TYPE_DEFAULT),
     m_iGroupId(-1),
     m_bLoaded(false),
     m_bChanged(false),
@@ -65,7 +65,7 @@ CPVRChannelGroup::CPVRChannelGroup(bool bRadio) :
 
 CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
     m_bRadio(group.bIsRadio),
-    m_bIsUserSetGroup(false),
+    m_iGroupType(PVR_GROUP_TYPE_DEFAULT),
     m_iGroupId(-1),
     m_strGroupName(group.strGroupName),
     m_bLoaded(false),
@@ -84,7 +84,7 @@ bool CPVRChannelGroup::operator==(const CPVRChannelGroup& right) const
   if (this == &right) return true;
 
   return (m_bRadio == right.m_bRadio &&
-      m_bIsUserSetGroup == right.m_bIsUserSetGroup &&
+      m_iGroupType == right.m_iGroupType &&
       m_iGroupId == right.m_iGroupId &&
       m_strGroupName.Equals(right.m_strGroupName));
 }
@@ -97,7 +97,7 @@ bool CPVRChannelGroup::operator!=(const CPVRChannelGroup &right) const
 CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group)
 {
   m_bRadio                      = group.m_bRadio;
-  m_bIsUserSetGroup             = group.m_bIsUserSetGroup;
+  m_iGroupType                  = group.m_iGroupType;
   m_iGroupId                    = group.m_iGroupId;
   m_strGroupName                = group.m_strGroupName;
   m_bLoaded                     = group.m_bLoaded;
@@ -145,7 +145,7 @@ void CPVRChannelGroup::Unload(void)
 
 bool CPVRChannelGroup::Update(void)
 {
-  if (IsUserSetGroup())
+  if (GroupType() == PVR_GROUP_TYPE_USER_DEFINED)
     return false;
 
   CPVRChannelGroup PVRChannels_tmp(m_bRadio, m_iGroupId, m_strGroupName);

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -190,6 +190,17 @@ namespace PVR
     virtual void SetGroupID(int iGroupId) { m_iGroupId = iGroupId; }
 
     /*!
+     * @brief Set the m_bIsUserSetGroup bool of this group.
+     * @param the new bIsUserSetGroup bool.
+     */
+    virtual void SetUserSetGroup(bool bIsUserSetGroup) { m_bIsUserSetGroup = bIsUserSetGroup; }
+
+    /*!
+     * @brief Return the m_bIsUserSetGroup bool of this group.
+     */
+    virtual bool IsUserSetGroup(void) const { return m_bIsUserSetGroup; }
+
+    /*!
      * @brief The name of this group.
      * @return The name of this group.
      */
@@ -427,6 +438,7 @@ namespace PVR
     virtual CPVRChannel *GetByChannelUpDown(const CPVRChannel &channel, bool bChannelUp) const;
 
     bool             m_bRadio;                      /*!< true if this container holds radio channels, false if it holds TV channels */
+    bool             m_bIsUserSetGroup;             /*!< true if this is a group created by the user, false otherwise */
     int              m_iGroupId;                    /*!< The ID of this group in the database */
     CStdString       m_strGroupName;                /*!< The name of this group */
     bool             m_bLoaded;                     /*!< True if this container is loaded, false otherwise */

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -35,6 +35,10 @@ namespace PVR
 #define XBMC_INTERNAL_GROUP_RADIO 1
 #define XBMC_INTERNAL_GROUP_TV    2
 
+#define PVR_GROUP_TYPE_DEFAULT      0
+#define PVR_GROUP_TYPE_INTERNAL     1
+#define PVR_GROUP_TYPE_USER_DEFINED 2
+
   class CPVRChannelGroups;
   class CPVRChannelGroupInternal;
 
@@ -190,15 +194,15 @@ namespace PVR
     virtual void SetGroupID(int iGroupId) { m_iGroupId = iGroupId; }
 
     /*!
-     * @brief Set the m_bIsUserSetGroup bool of this group.
-     * @param the new bIsUserSetGroup bool.
+     * @brief Set the type of this group.
+     * @param the new type for this group.
      */
-    virtual void SetUserSetGroup(bool bIsUserSetGroup) { m_bIsUserSetGroup = bIsUserSetGroup; }
+    virtual void SetGroupType(int iGroupType) { m_iGroupType = iGroupType; }
 
     /*!
-     * @brief Return the m_bIsUserSetGroup bool of this group.
+     * @brief Return the type of this group.
      */
-    virtual bool IsUserSetGroup(void) const { return m_bIsUserSetGroup; }
+    virtual int GroupType(void) const { return m_iGroupType; }
 
     /*!
      * @brief The name of this group.
@@ -438,7 +442,7 @@ namespace PVR
     virtual CPVRChannel *GetByChannelUpDown(const CPVRChannel &channel, bool bChannelUp) const;
 
     bool             m_bRadio;                      /*!< true if this container holds radio channels, false if it holds TV channels */
-    bool             m_bIsUserSetGroup;             /*!< true if this is a group created by the user, false otherwise */
+    int              m_iGroupType;                  /*!< The type of this group */
     int              m_iGroupId;                    /*!< The ID of this group in the database */
     CStdString       m_strGroupName;                /*!< The name of this group */
     bool             m_bLoaded;                     /*!< True if this container is loaded, false otherwise */

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -40,6 +40,7 @@ CPVRChannelGroupInternal::CPVRChannelGroupInternal(bool bRadio) :
   CPVRChannelGroup(bRadio)
 {
   m_iHiddenChannels = 0;
+  m_iGroupType      = PVR_GROUP_TYPE_INTERNAL;
   m_iGroupId        = bRadio ? XBMC_INTERNAL_GROUP_RADIO : XBMC_INTERNAL_GROUP_TV;
   m_strGroupName    = g_localizeStrings.Get(bRadio ? 19216 : 19217);
 }

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -93,7 +93,7 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb)
   if (iIndex < 0)
   {
     CPVRChannelGroup *newGroup = new CPVRChannelGroup(m_bRadio, group.GroupID(), group.GroupName());
-    newGroup->SetUserSetGroup(group.IsUserSetGroup());
+    newGroup->SetGroupType(group.GroupType());
     if (bSaveInDb)
       newGroup->Persist();
 
@@ -103,7 +103,7 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb)
   {
     at(iIndex)->SetGroupID(group.GroupID());
     at(iIndex)->SetGroupName(group.GroupName());
-    at(iIndex)->SetUserSetGroup(group.IsUserSetGroup());
+    at(iIndex)->SetGroupType(group.GroupType());
 
     if (bSaveInDb)
       at(iIndex)->Persist();
@@ -223,7 +223,7 @@ bool CPVRChannelGroups::UpdateGroupsEntries(const CPVRChannelGroups &groups)
   {
     CPVRChannelGroup existingGroup(*at(iGroupPtr));
     CPVRChannelGroup *group = (CPVRChannelGroup *) groups.GetByName(existingGroup.GroupName());
-    if (!existingGroup.IsUserSetGroup() && group == NULL)
+    if (existingGroup.GroupType() == PVR_GROUP_TYPE_DEFAULT && group == NULL)
     {
       CLog::Log(LOGDEBUG, "PVRChannelGroups - %s - user defined group %s with ID '%u' does not exist on the client anymore. deleting",
           __FUNCTION__, existingGroup.GroupName().c_str(), existingGroup.GroupID());

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -93,6 +93,7 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb)
   if (iIndex < 0)
   {
     CPVRChannelGroup *newGroup = new CPVRChannelGroup(m_bRadio, group.GroupID(), group.GroupName());
+    newGroup->SetUserSetGroup(group.IsUserSetGroup());
     if (bSaveInDb)
       newGroup->Persist();
 
@@ -102,6 +103,7 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bSaveInDb)
   {
     at(iIndex)->SetGroupID(group.GroupID());
     at(iIndex)->SetGroupName(group.GroupName());
+    at(iIndex)->SetUserSetGroup(group.IsUserSetGroup());
 
     if (bSaveInDb)
       at(iIndex)->Persist();
@@ -221,7 +223,7 @@ bool CPVRChannelGroups::UpdateGroupsEntries(const CPVRChannelGroups &groups)
   {
     CPVRChannelGroup existingGroup(*at(iGroupPtr));
     CPVRChannelGroup *group = (CPVRChannelGroup *) groups.GetByName(existingGroup.GroupName());
-    if (group == NULL)
+    if (!existingGroup.IsUserSetGroup() && group == NULL)
     {
       CLog::Log(LOGDEBUG, "PVRChannelGroups - %s - user defined group %s with ID '%u' does not exist on the client anymore. deleting",
           __FUNCTION__, existingGroup.GroupName().c_str(), existingGroup.GroupID());

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -104,7 +104,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonNewGroup(CGUIMessage &message)
         CPVRChannelGroups *groups = ((CPVRChannelGroups *) g_PVRChannelGroups->Get(m_bIsRadio));
         if (groups->AddGroup(strGroupName))
         {
-          g_PVRChannelGroups->Get(m_bIsRadio)->GetByName(strGroupName)->SetUserSetGroup(true);
+          g_PVRChannelGroups->Get(m_bIsRadio)->GetByName(strGroupName)->SetGroupType(PVR_GROUP_TYPE_USER_DEFINED);
           m_iSelectedChannelGroup = groups->size() - 1;
           Update();
         }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -104,6 +104,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonNewGroup(CGUIMessage &message)
         CPVRChannelGroups *groups = ((CPVRChannelGroups *) g_PVRChannelGroups->Get(m_bIsRadio));
         if (groups->AddGroup(strGroupName))
         {
+          g_PVRChannelGroups->Get(m_bIsRadio)->GetByName(strGroupName)->SetUserSetGroup(true);
           m_iSelectedChannelGroup = groups->size() - 1;
           Update();
         }


### PR DESCRIPTION
Right now it's impossible to use user defined groups because they are either deleted because they don't exist in the backend (if group syncing is enabled) or the channels are removed from them because they don't exist in the backend (if group syncing is disabled). Either way the result is the same... after you reopen XBMC, the groups are not displayed.

This code extends the pvr database and adds a "is set by user" flag to user defined groups. A group flagged as "set by user" if it's created with the group manager. Flagged groups are not deleted/updated from the client.

This code also contains two other bug fixes:
1.) Don't reset the channel number cache on groups that are not being displayed. If a background group is updated (either by the backend or by the user) while being on the channel list results in a corrupted numbering.
2.) Default return true when persisting channel group members to prevent false returning when persisting (creating) a new (empty) group. This fixes the problem in the group manager where it was needed to close and reopen it to see the newly added group.
