### PR TITLE
PVR API extension as discussed via mail

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -127,6 +127,7 @@ libusb_disabled_udev_found="== libusb disabled. =="
 libcec_enabled="== libcec enabled. =="
 libcec_disabled="== libcec disabled. CEC adapter support will not be available. =="
 libcec_disabled_missing_libs="== libcec disabled because both libudev and libusb are not available. CEC adapter support will not be available. =="
+libbluray_wrong_version="version has old angle api which is not supported, if you want to continue disable libbluray support"
 
 # External library message strings
 external_libraries_enabled="== Use of all supported external libraries enabled. =="
@@ -777,7 +778,7 @@ AS_CASE([x$use_libbluray],
             [AC_LANG_PROGRAM(
                 [#include <libbluray/bluray.h>]
                ,[bd_get_playlist_info(0, 0)])]
-          ,[AC_MSG_ERROR(version has old angle api which is not supported, if you want to continue disable libbluray support)]
+          ,[AC_MSG_ERROR($libbluray_wrong_version)]
           ,[AC_MSG_RESULT(normal)]
         )
     )

--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -201,6 +201,22 @@ extern "C"
    */
   PVR_ERROR RenameRecording(const PVR_RECORDING &recording);
 
+  /*!
+  * @brief Set the last watched position of a recording on the backend.
+  * @param recording The recording.
+  * @param position The last watched position in seconds
+  * @return PVR_ERROR_NO_ERROR if the position has been stored
+  successfully.
+  */
+  PVR_ERROR SetRecordingLastWatchedPosition(const PVR_RECORDING &recording, int lastwatchedposition);
+
+  /*!
+  * @brief Retrieve the last watched position of a recording on the backend.
+  * @param recording The recording.
+  * @return The last watched position in seconds or -1 on error
+  */
+  int GetRecordingLastWatchedPosition(const PVR_RECORDING &recording);
+
   //@}
   /** @name PVR timer methods */
   //@{
@@ -406,6 +422,8 @@ extern "C"
     pClient->GetRecordings           = GetRecordings;
     pClient->DeleteRecording         = DeleteRecording;
     pClient->RenameRecording         = RenameRecording;
+    pClient->SetRecordingLastWatchedPosition = SetRecordingLastWatchedPosition;
+    pClient->GetRecordingLastWatchedPosition = GetRecordingLastWatchedPosition;
 
     pClient->GetTimersAmount         = GetTimersAmount;
     pClient->GetTimers               = GetTimers;

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -358,6 +358,8 @@ extern "C" {
     PVR_ERROR    (__cdecl* GetRecordings)(PVR_HANDLE handle);
     PVR_ERROR    (__cdecl* DeleteRecording)(const PVR_RECORDING &recording);
     PVR_ERROR    (__cdecl* RenameRecording)(const PVR_RECORDING &recording);
+    PVR_ERROR    (__cdecl* SetRecordingLastWatchedPosition)(const PVR_RECORDING &recording, int lastwatchedposition);
+    int          (__cdecl* GetRecordingLastWatchedPosition)(const PVR_RECORDING &recording);
     //@}
 
     /** @name PVR timer methods */

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -632,6 +632,58 @@ PVR_ERROR CPVRClient::RenameRecording(const CPVRRecording &recording)
   return retVal;
 }
 
+PVR_ERROR CPVRClient::SetRecordingLastWatchedPosition(const CPVRRecording &recording, int lastwatchedposition)
+{
+  PVR_ERROR retVal = PVR_ERROR_UNKNOWN;
+  if (!m_bReadyToUse)
+    return retVal;
+
+  if (!m_addonCapabilities.bSupportsRecordings)
+    return PVR_ERROR_NOT_IMPLEMENTED;
+
+  try
+  {
+    PVR_RECORDING tag;
+    PVRWriteClientRecordingInfo(recording, tag);
+
+    retVal = m_pStruct->SetRecordingLastWatchedPosition(tag, lastwatchedposition);
+
+    LogError(retVal, __FUNCTION__);
+  }
+  catch (exception &e)
+  {
+    CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call RenameRecording() on addon '%s'. please contact the developer of this addon: %s",
+        __FUNCTION__, e.what(), GetFriendlyName().c_str(), Author().c_str());
+  }
+
+  return retVal;
+}
+
+int CPVRClient::GetRecordingLastWatchedPosition(const CPVRRecording &recording)
+{
+  int iReturn = -1;
+  if (!m_bReadyToUse)
+    return iReturn;
+
+  if (!m_addonCapabilities.bSupportsRecordings)
+    return iReturn;
+
+  try
+  {
+    PVR_RECORDING tag;
+    PVRWriteClientRecordingInfo(recording, tag);
+
+    iReturn = m_pStruct->GetRecordingLastWatchedPosition(tag);
+  }
+  catch (exception &e)
+  {
+    CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call GetRecordingLastWatchedPosition() on addon '%s'. please contact the developer of this addon: %s",
+        __FUNCTION__, e.what(), GetFriendlyName().c_str(), Author().c_str());
+  }
+
+  return iReturn;
+}
+
 int CPVRClient::GetTimersAmount(void)
 {
   int iReturn = -1;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -256,6 +256,22 @@ namespace PVR
      */
     PVR_ERROR RenameRecording(const CPVRRecording &recording);
 
+    /*!
+    * @brief Set the last watched position of a recording on the backend.
+    * @param recording The recording.
+    * @param position The last watched position in seconds
+    * @return PVR_ERROR_NO_ERROR if the position has been stored
+    successfully.
+    */
+    PVR_ERROR SetRecordingLastWatchedPosition(const CPVRRecording &recording, int lastwatchedposition);
+
+    /*!
+    * @brief Retrieve the last watched position of a recording on the backend.
+    * @param recording The recording.
+    * @return The last watched position in seconds or -1 on error
+    */
+    int GetRecordingLastWatchedPosition(const CPVRRecording &recording);
+
     //@}
     /** @name PVR timer methods */
     //@{

--- a/xbmc/pvrclients/MediaPortal/client.cpp
+++ b/xbmc/pvrclients/MediaPortal/client.cpp
@@ -723,6 +723,9 @@ void DemuxAbort(void) {}
 void DemuxReset(void) {}
 void DemuxFlush(void) {}
 
+PVR_ERROR SetRecordingLastWatchedPosition(const PVR_RECORDING &recording, int lastwatchedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastWatchedPosition(const PVR_RECORDING &recording) { return -1; }
+
 long long SeekRecordedStream(long long iPosition, int iWhence) { return -1; }
 long long PositionRecordedStream(void) { return -1; }
 long long LengthRecordedStream(void) { return -1; }

--- a/xbmc/pvrclients/mythtv/client.cpp
+++ b/xbmc/pvrclients/mythtv/client.cpp
@@ -478,5 +478,7 @@ long long SeekLiveStream(long long iPosition, int iWhence) { return -1; }
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channelinfo) { return ""; }
+PVR_ERROR SetRecordingLastWatchedPosition(const PVR_RECORDING &recording, int lastwatchedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastWatchedPosition(const PVR_RECORDING &recording) { return -1; }
 
 } //end extern "C"

--- a/xbmc/pvrclients/pvr-demo/client.cpp
+++ b/xbmc/pvrclients/pvr-demo/client.cpp
@@ -280,6 +280,8 @@ int GetRecordingsAmount(void) { return -1; }
 PVR_ERROR GetRecordings(PVR_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR SetRecordingLastWatchedPosition(const PVR_RECORDING &recording, int lastwatchedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastWatchedPosition(const PVR_RECORDING &recording) { return -1; }
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(PVR_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -551,4 +551,6 @@ long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { re
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
+PVR_ERROR SetRecordingLastWatchedPosition(const PVR_RECORDING &recording, int lastwatchedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastWatchedPosition(const PVR_RECORDING &recording) { return -1; }
 }

--- a/xbmc/pvrclients/vdr-vnsi/client.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/client.cpp
@@ -638,5 +638,7 @@ long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { re
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
+PVR_ERROR SetRecordingLastWatchedPosition(const PVR_RECORDING &recording, int lastwatchedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastWatchedPosition(const PVR_RECORDING &recording) { return -1; }
 
 }


### PR DESCRIPTION
Lars, as we discussed, this is the pvr api extension to get / set last watched position for a recording from / to the backend. I've added stubs in all the pvr clients that were present.

Also, there is a small fix for configure.in. I noticed it since my Ubuntu seems not to have the proper api for libbluray and ./configure was crashing nicely while trying to tell me that ;).

Regards,
Fred
