### PR TITLE
Show the right info for currently recording  program(s).

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -759,11 +759,10 @@ void CPVRGUIInfo::UpdateTimersToggle(void)
   CStdString strActiveTimerTime;
 
   /* safe to fetch these unlocked, since they're updated from the same thread as this one */
-  unsigned int iBoundary = m_iRecordingTimerAmount > 0 ? m_iRecordingTimerAmount : m_iTimerAmount;
-  if (m_iTimerInfoToggleCurrent < iBoundary)
+  if (m_iRecordingTimerAmount > 0)
   {
     vector<CPVRTimerInfoTag *> activeTags;
-    g_PVRTimers->GetActiveTimers(&activeTags);
+    g_PVRTimers->GetActiveRecordings(&activeTags);
     if (activeTags.at(m_iTimerInfoToggleCurrent) != 0)
     {
       strActiveTimerTitle.Format("%s",       activeTags.at(m_iTimerInfoToggleCurrent)->m_strTitle);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -338,6 +338,23 @@ int CPVRTimers::GetNumActiveTimers(void) const
   return iReturn;
 }
 
+int CPVRTimers::GetActiveRecordings(vector<CPVRTimerInfoTag *> *tags) const
+{
+  int iInitialSize = tags->size();
+  CSingleLock lock(m_critSection);
+
+  for (map<CDateTime, vector<CPVRTimerInfoTag *>* >::const_iterator it = m_tags.begin(); it != m_tags.end(); it++)
+  {
+    for (unsigned int iTimerPtr = 0; iTimerPtr < it->second->size(); iTimerPtr++)
+    {
+      if (it->second->at(iTimerPtr)->IsRecording())
+        tags->push_back(it->second->at(iTimerPtr));
+    }
+  }
+
+  return tags->size() - iInitialSize;
+}
+
 int CPVRTimers::GetNumActiveRecordings(void) const
 {
   int iReturn(0);

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -80,6 +80,7 @@ namespace PVR
 
     int GetActiveTimers(std::vector<CPVRTimerInfoTag *> *tags) const;
 
+    int GetActiveRecordings(std::vector<CPVRTimerInfoTag *> *tags) const;
     /**
      * The amount of timers in this container.
      */


### PR DESCRIPTION
I would suggest to eventually review the name of some Method/Variable using the wording ActiveTimer
Some are confusing:
CPVRGUIInfo::CharInfoActiveTimerChannelName 
CPVRGUIInfo::m_strActiveTimerChannelName
Refer to one of the currents recordings. (m_state == PVR_TIMER_STATE_RECORDING)

and
CPVRTimers::GetActiveTimers
Refer to Active timer (m_state == PVR_TIMER_STATE_SCHEDULED || m_state == PVR_TIMER_STATE_RECORDING)

and CPVRTimers::GetNextActiveTimer
Refer to Next Scheduled timer (m_state == PVR_TIMER_STATE_SCHEDULED )
