### PR TITLE
PVR API Extenstion: Get/SetRecordingLastPlayedPosition

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_dll.h
+++ b/xbmc/addons/include/xbmc_pvr_dll.h
@@ -201,6 +201,22 @@ extern "C"
    */
   PVR_ERROR RenameRecording(const PVR_RECORDING &recording);
 
+  /*!
+  * @brief Set the last watched position of a recording on the backend.
+  * @param recording The recording.
+  * @param position The last watched position in seconds
+  * @return PVR_ERROR_NO_ERROR if the position has been stored
+  successfully.
+  */
+  PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
+
+  /*!
+  * @brief Retrieve the last watched position of a recording on the backend.
+  * @param recording The recording.
+  * @return The last watched position in seconds or -1 on error
+  */
+  int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
+
   //@}
   /** @name PVR timer methods */
   //@{
@@ -406,6 +422,8 @@ extern "C"
     pClient->GetRecordings           = GetRecordings;
     pClient->DeleteRecording         = DeleteRecording;
     pClient->RenameRecording         = RenameRecording;
+    pClient->SetRecordingLastPlayedPosition = SetRecordingLastPlayedPosition;
+    pClient->GetRecordingLastPlayedPosition = GetRecordingLastPlayedPosition;
 
     pClient->GetTimersAmount         = GetTimersAmount;
     pClient->GetTimers               = GetTimers;

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -358,6 +358,8 @@ extern "C" {
     PVR_ERROR    (__cdecl* GetRecordings)(PVR_HANDLE handle);
     PVR_ERROR    (__cdecl* DeleteRecording)(const PVR_RECORDING &recording);
     PVR_ERROR    (__cdecl* RenameRecording)(const PVR_RECORDING &recording);
+    PVR_ERROR    (__cdecl* SetRecordingLastPlayedPosition)(const PVR_RECORDING &recording, int lastplayedposition);
+    int          (__cdecl* GetRecordingLastPlayedPosition)(const PVR_RECORDING &recording);
     //@}
 
     /** @name PVR timer methods */

--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -158,6 +158,7 @@ extern "C" {
     bool bHandlesInputStream;           /*!< @brief (optional) true if this add-on provides an input stream. false if XBMC handles the stream. */
     bool bHandlesDemuxing;              /*!< @brief (optional) true if this add-on demultiplexes packets. */
     bool bSupportsRecordingFolders;     /*!< @brief (optional) true if the backend supports timers / recordings in folders. */
+    bool bSupportsLastPlayedPosition;   /*!< @brief (optional) true if the backend supports store/retrieve of last played position for recordings. */
   } ATTRIBUTE_PACKED PVR_ADDON_CAPABILITIES;
 
   /*!

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2022,6 +2022,11 @@ void CDVDPlayer::OnExit()
     }
     m_pSubtitleDemuxer = NULL;
 
+    if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) && g_PVRManager.IsPlayingRecording())
+    {
+      g_PVRManager.UpdateCurrentLastPlayedPosition(m_State.time / 1000);
+    }
+
     // destroy the inputstream
     if (m_pInputStream)
     {

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -279,8 +279,10 @@ void CPVRManager::StopUpdateThreads(void)
   SetState(ManagerStateInterrupted);
 
   StopThread();
-  m_guiInfo->Stop();
-  m_addons->Stop();
+  if (m_guiInfo)
+    m_guiInfo->Stop();
+  if (m_addons)
+    m_addons->Stop();
 }
 
 bool CPVRManager::Load(void)
@@ -821,6 +823,47 @@ bool CPVRManager::UpdateItem(CFileItem& item)
     m_LastChannelChanged = XbmcThreads::SystemClockMillis();
 
   return false;
+}
+
+
+bool CPVRManager::UpdateCurrentLastPlayedPosition(int lastplayedposition)
+{
+  // Only anything but recordings we fake success
+  if (!IsPlayingRecording())
+    return true;
+
+  bool rc = false;
+  CPVRRecording currentRecording;
+
+  if (m_addons)
+  {
+    PVR_ERROR error;
+    rc = m_addons->GetPlayingRecording(currentRecording) && m_addons->SetRecordingLastPlayedPosition(currentRecording, lastplayedposition, &error);
+  }
+  return rc;
+}
+
+bool CPVRManager::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition)
+{
+  bool rc = false;
+
+  if (m_addons)
+  {
+    PVR_ERROR error;
+    rc = m_addons->SetRecordingLastPlayedPosition(recording, lastplayedposition, &error);
+  }
+  return rc;
+}
+
+int CPVRManager::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
+{
+  int rc = 0;
+
+  if (m_addons)
+  {
+    rc = m_addons->GetRecordingLastPlayedPosition(recording);
+  }
+  return rc;
 }
 
 bool CPVRManager::StartPlayback(const CPVRChannel *channel, bool bPreview /* = false */)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -423,6 +423,27 @@ namespace PVR
      */
     void LoadCurrentChannelSettings(void);
 
+    /*!
+     * @brief Update the last played position for the current playing file
+     * @param lastplayedposition channel The channel to start to play.
+     */
+    bool UpdateCurrentLastPlayedPosition(int lastplayedposition);
+
+    /*!
+     * @brief Set the last watched position of a recording on the backend.
+     * @param recording The recording.
+     * @param position The last watched position in seconds
+     * @return True if the last played position was updated successfully, false otherwise
+    */
+    bool SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition);
+
+    /*!
+    * @brief Retrieve the last watched position of a recording on the backend.
+    * @param recording The recording.
+    * @return The last watched position in seconds
+    */
+    int GetRecordingLastPlayedPosition(const CPVRRecording &recording);
+
   protected:
     /*!
      * @brief PVR update and control thread.

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -634,6 +634,59 @@ PVR_ERROR CPVRClient::RenameRecording(const CPVRRecording &recording)
   return retVal;
 }
 
+PVR_ERROR CPVRClient::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition)
+{
+  PVR_ERROR retVal = PVR_ERROR_UNKNOWN;
+  if (!m_bReadyToUse)
+    return retVal;
+
+  if (!m_addonCapabilities.bSupportsRecordings)
+    return PVR_ERROR_NOT_IMPLEMENTED;
+
+  try
+  {
+    PVR_RECORDING tag;
+    PVRWriteClientRecordingInfo(recording, tag);
+
+    retVal = m_pStruct->SetRecordingLastPlayedPosition(tag, lastplayedposition);
+
+    if (retVal != PVR_ERROR_NOT_IMPLEMENTED)
+      LogError(retVal, __FUNCTION__);
+  }
+  catch (exception &e)
+  {
+    CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call RenameRecording() on addon '%s'. please contact the developer of this addon: %s",
+        __FUNCTION__, e.what(), GetFriendlyName().c_str(), Author().c_str());
+  }
+
+  return retVal;
+}
+
+int CPVRClient::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
+{
+  int iReturn = -1;
+  if (!m_bReadyToUse)
+    return iReturn;
+
+  if (!m_addonCapabilities.bSupportsRecordings)
+    return iReturn;
+
+  try
+  {
+    PVR_RECORDING tag;
+    PVRWriteClientRecordingInfo(recording, tag);
+
+    iReturn = m_pStruct->GetRecordingLastPlayedPosition(tag);
+  }
+  catch (exception &e)
+  {
+    CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call GetRecordingLastPlayedPosition() on addon '%s'. please contact the developer of this addon: %s",
+        __FUNCTION__, e.what(), GetFriendlyName().c_str(), Author().c_str());
+  }
+
+  return iReturn;
+}
+
 int CPVRClient::GetTimersAmount(void)
 {
   int iReturn = -1;

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -97,6 +97,7 @@ void CPVRClient::ResetAddonCapabilities(void)
   m_addonCapabilities.bHandlesInputStream       = false;
   m_addonCapabilities.bHandlesDemuxing          = false;
   m_addonCapabilities.bSupportsRecordingFolders = false;
+  m_addonCapabilities.bSupportsLastPlayedPosition = false;
 }
 
 bool CPVRClient::Create(int iClientId)
@@ -640,7 +641,7 @@ PVR_ERROR CPVRClient::SetRecordingLastPlayedPosition(const CPVRRecording &record
   if (!m_bReadyToUse)
     return retVal;
 
-  if (!m_addonCapabilities.bSupportsRecordings)
+  if (!m_addonCapabilities.bSupportsLastPlayedPosition)
     return PVR_ERROR_NOT_IMPLEMENTED;
 
   try
@@ -650,12 +651,11 @@ PVR_ERROR CPVRClient::SetRecordingLastPlayedPosition(const CPVRRecording &record
 
     retVal = m_pStruct->SetRecordingLastPlayedPosition(tag, lastplayedposition);
 
-    if (retVal != PVR_ERROR_NOT_IMPLEMENTED)
-      LogError(retVal, __FUNCTION__);
+    LogError(retVal, __FUNCTION__);
   }
   catch (exception &e)
   {
-    CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call RenameRecording() on addon '%s'. please contact the developer of this addon: %s",
+    CLog::Log(LOGERROR, "PVRClient - %s - exception '%s' caught while trying to call SetRecordingLastPlayedPosition() on addon '%s'. please contact the developer of this addon: %s",
         __FUNCTION__, e.what(), GetFriendlyName().c_str(), Author().c_str());
   }
 
@@ -668,7 +668,7 @@ int CPVRClient::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
   if (!m_bReadyToUse)
     return iReturn;
 
-  if (!m_addonCapabilities.bSupportsRecordings)
+  if (!m_addonCapabilities.bSupportsLastPlayedPosition)
     return iReturn;
 
   try

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -256,6 +256,22 @@ namespace PVR
      */
     PVR_ERROR RenameRecording(const CPVRRecording &recording);
 
+    /*!
+    * @brief Set the last watched position of a recording on the backend.
+    * @param recording The recording.
+    * @param position The last watched position in seconds
+    * @return PVR_ERROR_NO_ERROR if the position has been stored
+    successfully.
+    */
+    PVR_ERROR SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition);
+
+    /*!
+    * @brief Retrieve the last watched position of a recording on the backend.
+    * @param recording The recording.
+    * @return The last watched position in seconds or -1 on error
+    */
+    int GetRecordingLastPlayedPosition(const CPVRRecording &recording);
+
     //@}
     /** @name PVR timer methods */
     //@{

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -797,6 +797,30 @@ bool CPVRClients::DeleteRecording(const CPVRRecording &recording, PVR_ERROR *err
 
   return *error == PVR_ERROR_NO_ERROR;
 }
+bool CPVRClients::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVR_ERROR *error)
+{
+  *error = PVR_ERROR_UNKNOWN;
+  boost::shared_ptr<CPVRClient> client;
+  if (GetConnectedClient(recording.m_iClientId, client) && client->GetAddonCapabilities().bSupportsRecordings)
+    *error = client->SetRecordingLastPlayedPosition(recording, lastplayedposition);
+  else
+    CLog::Log(LOGERROR, "PVR - %s - client %d does not support recordings",__FUNCTION__, recording.m_iClientId);
+
+  return *error == PVR_ERROR_NO_ERROR;
+}
+
+int CPVRClients::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
+{
+  int rc = 0;
+
+  boost::shared_ptr<CPVRClient> client;
+  if (GetConnectedClient(recording.m_iClientId, client) && client->GetAddonCapabilities().bSupportsRecordings)
+    rc = client->GetRecordingLastPlayedPosition(recording);
+  else
+    CLog::Log(LOGERROR, "PVR - %s - client %d does not support recordings",__FUNCTION__, recording.m_iClientId);
+
+  return rc;
+}
 
 bool CPVRClients::IsRecordingOnPlayingChannel(void) const
 {

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -465,6 +465,22 @@ namespace PVR
     bool DeleteRecording(const CPVRRecording &recording, PVR_ERROR *error);
 
     /*!
+     * @brief Set the last watched position of a recording on the backend.
+     * @param recording The recording.
+     * @param position The last watched position in seconds
+     * @param error An error if it occured.
+     * @return True if the last played position was updated successfully, false otherwise
+    */
+    bool SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVR_ERROR *error);
+
+    /*!
+    * @brief Retrieve the last watched position of a recording on the backend.
+    * @param recording The recording.
+    * @return The last watched position in seconds
+    */
+    int GetRecordingLastPlayedPosition(const CPVRRecording &recording);
+
+    /*!
      * @brief Check whether there is an active recording on the current channel.
      * @return True if there is, false otherwise.
      */

--- a/xbmc/pvrclients/MediaPortal/client.cpp
+++ b/xbmc/pvrclients/MediaPortal/client.cpp
@@ -730,5 +730,7 @@ long long LengthRecordedStream(void) { return -1; }
 long long SeekLiveStream(long long pos, int whence) { return -1; }
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1 ; }
+PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 
 } //end extern "C"

--- a/xbmc/pvrclients/MediaPortal/client.cpp
+++ b/xbmc/pvrclients/MediaPortal/client.cpp
@@ -402,6 +402,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities)
   pCapabilities->bHandlesInputStream         = true;
   pCapabilities->bHandlesDemuxing            = false;
   pCapabilities->bSupportsChannelScan        = false;
+  pCapabilities->bSupportsLastPlayedPosition = false;
 
   return PVR_ERROR_NO_ERROR;
 }

--- a/xbmc/pvrclients/pvr-demo/client.cpp
+++ b/xbmc/pvrclients/pvr-demo/client.cpp
@@ -280,6 +280,8 @@ int GetRecordingsAmount(void) { return -1; }
 PVR_ERROR GetRecordings(PVR_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(PVR_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/xbmc/pvrclients/pvr-demo/client.cpp
+++ b/xbmc/pvrclients/pvr-demo/client.cpp
@@ -132,6 +132,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsChannelScan     = false;
   pCapabilities->bHandlesInputStream      = false;
   pCapabilities->bHandlesDemuxing         = false;
+  pCapabilities->bSupportsLastPlayedPosition = false;
 
   return PVR_ERROR_NO_ERROR;
 }

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -551,4 +551,6 @@ long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { re
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
+PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 }

--- a/xbmc/pvrclients/tvheadend/client.cpp
+++ b/xbmc/pvrclients/tvheadend/client.cpp
@@ -294,6 +294,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsChannelScan     = false;
   pCapabilities->bHandlesInputStream      = true;
   pCapabilities->bHandlesDemuxing         = true;
+  pCapabilities->bSupportsLastPlayedPosition = false;
 
   return PVR_ERROR_NO_ERROR;
 }

--- a/xbmc/pvrclients/vdr-vnsi/client.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/client.cpp
@@ -638,5 +638,7 @@ long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { re
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
+PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
+int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 
 }

--- a/xbmc/pvrclients/vdr-vnsi/client.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/client.cpp
@@ -307,6 +307,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
     pCapabilities->bSupportsChannelScan      = true;
   else
     pCapabilities->bSupportsChannelScan      = false;
+  pCapabilities->bSupportsLastPlayedPosition = false;
 
   return PVR_ERROR_NO_ERROR;
 }


### PR DESCRIPTION
This supersedes PR #513

Lars, as we discussed, this is the pvr api extension to get / set last watched position for a recording from / to the backend. I've added stubs in all the pvr clients that were present.

The api functions have been renamed to Get/SetRecordingLastPlayedPosition, as requested in the comments on PR# 513.

The calling of the new API functions have been wired into the existing code. 

GetRecordingLastPlayedPosition is called from xbmc/pvr/windows/GUIWindowPVRRecordings.cpp. The code will attempt to retrieve the last saved position from the back-end first, when successful a corresponding resume bookmark will be created in the video database since the recording may have been viewed on another device or with other software then the current XBMC. If there is no saved position on the back-end, or the functionality is not supported the code will try to fetch a resume bookmark from the video database just as it used to do.

SetRecordingLastPlayedPosition is called from xbmc/cores/dvdplayer/DVDPlayer.cpp, after much consideration. The reason for calling it there and not from xbmc/utils/SaveFileStateJob.h is that the time offset for the played file is NOT ALWAYS guaranteed to be filled in the SaveFileStateJob.

The code is working with the ForTheRecord add-on on Linux x86 and Windows (x86 and x64). I tried to build for OSX and iOS too, but the build is broken at the moment and after manually updating three of four of the makefiles I gave up. Will build and test on Linux x64 later this weekend.

Regards,
Fred
