### PR TITLE
makefiles

### DIFF
--- a/xbmc/pvrclients/MediaPortal/Makefile.in
+++ b/xbmc/pvrclients/MediaPortal/Makefile.in
@@ -7,7 +7,10 @@
 
 LIBS   = lib/tinyxml/tinyxml.a -ldl
 LIBDIR = @abs_top_srcdir@/addons/pvr.team-mediaportal.tvserver
-LIB    = $(LIBDIR)/XBMC_MPTV.pvr
+PVR    = $(LIBDIR)/XBMC_MPTV.pvr
+CLEAN_FILES = *.P *~ $(PVR)
+
+pvr: $(PVR)
 
 SRCS   = channels.cpp \
 	client.cpp \
@@ -23,11 +26,11 @@ SRCS   = channels.cpp \
 
 include ../Makefile.include
 
-clean:
-	-rm -f $(OBJS) $(LIB) *.P *~
+cleanlibs:
 	$(MAKE) -C lib/tinyxml clean
 
+clean: cleanlibs
 
-$(LIB): $(OBJS)
+$(PVR): $(OBJS)
 	$(MAKE) -C lib/tinyxml
-	$(SILENT_CPP) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -g $(OBJS) $(LIBS) $(LIBDIRS) $(SILIB) -o $(LIB)
+	$(SILENT_CPP) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -g $(OBJS) $(LIBS) $(LIBDIRS) $(SILIB) -o $(PVR)

--- a/xbmc/pvrclients/tvheadend/Makefile.in
+++ b/xbmc/pvrclients/tvheadend/Makefile.in
@@ -7,7 +7,10 @@
 
 LIBS   = @abs_top_srcdir@/lib/libhts/libhts.a -ldl
 LIBDIR = @abs_top_srcdir@/addons/pvr.hts
-LIB    = @abs_top_srcdir@/addons/pvr.hts/XBMC_Tvheadend.pvr
+PVR    = @abs_top_srcdir@/addons/pvr.hts/XBMC_Tvheadend.pvr
+CLEAN_FILES = *.P *~ $(PVR)
+
+pvr: $(PVR)
 
 SRCS=client.cpp \
      HTSPConnection.cpp \
@@ -16,10 +19,11 @@ SRCS=client.cpp \
 
 include ../Makefile.include
 
-clean:
-	-rm -f $(OBJS) $(LIB) *.P *~
+cleanlibs:
 	$(MAKE) -C @abs_top_srcdir@/lib/libhts clean
+	
+clean: cleanlibs
 
-$(LIB): $(OBJS)
+$(PVR): $(OBJS)
 	${MAKE} -C @abs_top_srcdir@/lib/libhts
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -g $(OBJS) $(LIBS) $(LIBDIRS) $(SILIB) -o $(LIB)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -g $(OBJS) $(LIBS) $(LIBDIRS) $(SILIB) -o $(PVR)

--- a/xbmc/pvrclients/vdr-vnsi/Makefile.in
+++ b/xbmc/pvrclients/vdr-vnsi/Makefile.in
@@ -7,7 +7,10 @@
 
 LIBS   = -ldl
 LIBDIR = @abs_top_srcdir@/addons/pvr.vdr.vnsi
-LIB    = @abs_top_srcdir@/addons/pvr.vdr.vnsi/XBMC_VDR_vnsi.pvr
+PVR    = @abs_top_srcdir@/addons/pvr.vdr.vnsi/XBMC_VDR_vnsi.pvr
+CLEAN_FILES = *.P *~ $(PVR)
+
+pvr: $(PVR)
 
 SRCS   = client.cpp \
 	VNSIChannelScan.cpp \
@@ -21,9 +24,6 @@ SRCS   = client.cpp \
 
 include ../Makefile.include
 
-clean:
-	-rm -f $(OBJS) $(LIB) *.P *~
-
-$(LIB): $(OBJS)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -g $(OBJS) $(LIBS) $(LIBDIRS) $(SILIB) -o $(LIB)
+$(PVR): $(OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -g $(OBJS) $(LIBS) $(LIBDIRS) $(SILIB) -o $(PVR)
 


### PR DESCRIPTION
This will fix the make warnings like:

Makefile:20: warning: overriding commands for target `clean'
/home/fred/Xbmc/xbmc/Makefile.include:133: warning: ignoring old commands for target`clean'
Makefile:24: warning: overriding commands for target `/home/fred/Xbmc/xbmc/addons/pvr.hts/XBMC_Tvheadend.pvr'
/home/fred/Xbmc/xbmc/Makefile.include:127: warning: ignoring old commands for target`/home/fred/Xbmc/xbmc/addons/pvr.hts/XBMC_Tvheadend.pvr'

for the tvheadend, mediaportal and vdr-vnsi add-ons
