### PR TITLE
PVR Window: Fix fullscreen switch behaviour when playminimized is turned off

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -655,18 +655,16 @@ bool CGUIWindowPVRCommon::PlayRecording(CFileItem *item, bool bPlayMinimized /* 
 
 bool CGUIWindowPVRCommon::PlayFile(CFileItem *item, bool bPlayMinimized /* = false */)
 {
+  if (item->GetPath() == g_application.CurrentFile())
+  {
+    CGUIMessage msg(GUI_MSG_FULLSCREEN, 0, m_parent->GetID());
+    g_windowManager.SendMessage(msg);
+    return true;
+  }
+
   if (bPlayMinimized)
   {
-    if (item->GetPath() == g_application.CurrentFile())
-    {
-      CGUIMessage msg(GUI_MSG_FULLSCREEN, 0, m_parent->GetID());
-      g_windowManager.SendMessage(msg);
-      return true;
-    }
-    else
-    {
-      g_settings.m_bStartVideoWindowed = true;
-    }
+    g_settings.m_bStartVideoWindowed = true;
   }
 
   if (item->GetPath().Left(17) == "pvr://recordings/")


### PR DESCRIPTION
Right now there is a bug if you turn off "Start playback minimized". When you start a channel it automatically starts in full screen (which is ok). But if you then return to the channel list (backspace or any other keymap that does the same thing) you will be unable to return to full screen until you stop and restart playback (or use a special shortcut to return to full screen).

This patch fixes the described bug.
