### PR TITLE
Wakeup script fixes and additons

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -73,6 +73,9 @@
 #include "storage/DetectDVDType.h"
 #include "ThumbLoader.h"
 
+#include "pvr/PVRManager.h"
+
+using namespace PVR;
 using namespace std;
 
 CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay) : CThread("CDelayedMessage")
@@ -261,12 +264,14 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
     case TMSG_HIBERNATE:
       {
+        g_PVRManager.SetWakeupCommand();
         g_powerManager.Hibernate();
       }
       break;
 
     case TMSG_SUSPEND:
       {
+        g_PVRManager.SetWakeupCommand();
         g_powerManager.Suspend();
       }
       break;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -423,6 +423,11 @@ namespace PVR
      */
     void LoadCurrentChannelSettings(void);
 
+    /*!
+     * @brief Executes "pvrpowermanagement.setwakeupcmd"
+     */
+    bool SetWakeupCommand(void);
+
   protected:
     /*!
      * @brief PVR update and control thread.
@@ -496,11 +501,6 @@ namespace PVR
      * @param iProgress The current progress in %.
      */
     void ShowProgressDialog(const CStdString &strText, int iProgress);
-
-    /*!
-     * @brief Executes "pvrpowermanagement.setwakeupcmd"
-     */
-    bool SetWakeupCommand(void);
 
     /*!
      * @brief Hide the progress dialog if it's visible.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -714,8 +714,7 @@ CDateTime CPVRTimers::GetNextEventTime(void) const
   const CDateTimeSpan prewakeup(0, 0, g_guiSettings.GetInt("pvrpowermanagement.prewakeup"), 0);
   const CDateTimeSpan idle(0, 0, g_guiSettings.GetInt("pvrpowermanagement.backendidletime"), 0);
 
-  CDateTime timerwakeuptime;
-  CDateTime dailywakeuptime;
+  CDateTime wakeuptime;
 
   /* Check next active time */
   CPVRTimerInfoTag timer;
@@ -724,15 +723,16 @@ CDateTime CPVRTimers::GetNextEventTime(void) const
     const CDateTime start = timer.StartAsUTC();
 
     if ((start - idle) > now) {
-      timerwakeuptime = start - prewakeup;
+      wakeuptime = start - prewakeup;
     } else {
-      timerwakeuptime = now + idle;
+      wakeuptime = now + idle;
     }
   }
 
   /* check daily wake up */
   if (dailywakup)
   {
+    CDateTime dailywakeuptime;
     dailywakeuptime.SetFromDBTime(g_guiSettings.GetString("pvrpowermanagement.dailywakeuptime", false));
     dailywakeuptime = dailywakeuptime.GetAsUTCDateTime();
 
@@ -746,8 +746,10 @@ CDateTime CPVRTimers::GetNextEventTime(void) const
       const CDateTimeSpan oneDay(1,0,0,0);
       dailywakeuptime += oneDay;
     }
+    if (dailywakeuptime < wakeuptime)
+      wakeuptime = dailywakeuptime;
   }
 
-  const CDateTime retVal((dailywakeuptime < timerwakeuptime) ? dailywakeuptime : timerwakeuptime);
+  const CDateTime retVal(wakeuptime);
   return retVal;
 }


### PR DESCRIPTION
Currently the wakeup script doesn't work if daily wakeup is disabled because the uninitialized daily wakeup time is always lower than the timer wakeup time and therefore always used (even if disabled). The first commit fixes this problem (the daily wakeup time is used only if enabled).

The second commit extends the functionality by calling the wakeup script also on suspend and hibernate (currently it's only called on shutdown).
