### PR TITLE
Vnsi fixes

### DIFF
--- a/xbmc/pvrclients/vdr-vnsi/VNSIData.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSIData.cpp
@@ -29,21 +29,17 @@ using namespace ADDON;
 using namespace PLATFORM;
 
 cVNSIData::cVNSIData()
- : m_aborting(false)
 {
 }
 
 cVNSIData::~cVNSIData()
 {
-  Abort();
   StopThread();
   Close();
 }
 
 bool cVNSIData::Open(const std::string& hostname, int port, const char* name)
 {
-  m_aborting = false;
-
   if(!cVNSISession::Open(hostname, port, name))
     return false;
 
@@ -57,23 +53,6 @@ bool cVNSIData::Login()
 
   CreateThread();
   return true;
-}
-
-void cVNSIData::Abort()
-{
-  CLockObject lock(m_mutex);
-  m_aborting = true;
-  cVNSISession::Abort();
-}
-
-void cVNSIData::SignalConnectionLost()
-{
-  CLockObject lock(m_mutex);
-
-  if(m_aborting)
-    return;
-
-  cVNSISession::SignalConnectionLost();
 }
 
 void cVNSIData::OnDisconnect()

--- a/xbmc/pvrclients/vdr-vnsi/VNSIData.h
+++ b/xbmc/pvrclients/vdr-vnsi/VNSIData.h
@@ -38,7 +38,6 @@ public:
 
   bool        Open(const std::string& hostname, int port, const char* name = NULL);
   bool        Login();
-  void        Abort();
 
   bool        SupportChannelScan();
   bool        EnableStatusInterface(bool onOff);
@@ -72,7 +71,6 @@ protected:
   virtual void *Process(void);
   virtual bool OnResponsePacket(cResponsePacket *pkt);
 
-  void SignalConnectionLost();
   void OnDisconnect();
   void OnReconnect();
 
@@ -89,6 +87,5 @@ private:
 
   SMessages        m_queue;
   std::string      m_videodir;
-  bool             m_aborting;
   PLATFORM::CMutex m_mutex;
 };

--- a/xbmc/pvrclients/vdr-vnsi/VNSIDemux.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSIDemux.cpp
@@ -84,7 +84,7 @@ DemuxPacket* cVNSIDemux::Read()
     return NULL;
   }
 
-  cResponsePacket *resp = ReadMessage();
+  cResponsePacket *resp = ReadMessage(1000,1000);
 
   if(resp == NULL)
     return PVR->AllocateDemuxPacket(0);

--- a/xbmc/pvrclients/vdr-vnsi/VNSIDemux.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSIDemux.cpp
@@ -74,7 +74,6 @@ bool cVNSIDemux::GetStreamProperties(PVR_STREAM_PROPERTIES* props)
 void cVNSIDemux::Abort()
 {
   m_Streams.iStreamCount = 0;
-  cVNSISession::Abort();
 }
 
 DemuxPacket* cVNSIDemux::Read()

--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -55,14 +55,6 @@ cVNSISession::~cVNSISession()
   Close();
 }
 
-void cVNSISession::Abort()
-{
-  if (!m_socket)
-    return;
-
-  m_socket->Shutdown();
-}
-
 void cVNSISession::Close()
 {
   if(IsOpen())
@@ -348,7 +340,6 @@ void cVNSISession::SignalConnectionLost()
   XBMC->Log(LOG_ERROR, "%s - connection lost !!!", __FUNCTION__);
 
   m_connectionLost = true;
-  Abort();
   Close();
 
   OnDisconnect();

--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.cpp
@@ -151,9 +151,12 @@ bool cVNSISession::Login()
   catch (const char * str)
   {
     XBMC->Log(LOG_ERROR, "%s - %s", __FUNCTION__,str);
-    m_socket->Close();
-    delete m_socket;
-    m_socket = NULL;
+    if (m_socket)
+    {
+      m_socket->Close();
+      delete m_socket;
+      m_socket = NULL;
+    }
     return false;
   }
 

--- a/xbmc/pvrclients/vdr-vnsi/VNSISession.h
+++ b/xbmc/pvrclients/vdr-vnsi/VNSISession.h
@@ -42,7 +42,6 @@ public:
   virtual bool      Open(const std::string& hostname, int port, const char *name = NULL);
   virtual bool      Login();
   virtual void      Close();
-  virtual void      Abort();
 
   cResponsePacket*  ReadMessage(int iInitialTimeout = 10000, int iDatapacketTimeout = 10000);
   bool              TransmitMessage(cRequestPacket* vrp);

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
@@ -54,12 +54,12 @@ protected:
   virtual void Receive(uchar *Data, int Length);
 
 public:
-  cLiveReceiver(cLiveStreamer *Streamer, tChannelID ChannelID, int Priority, const int *Pids);
+  cLiveReceiver(cLiveStreamer *Streamer, const cChannel *Channel, int Priority, const int *Pids);
   virtual ~cLiveReceiver();
 };
 
-cLiveReceiver::cLiveReceiver(cLiveStreamer *Streamer, tChannelID ChannelID, int Priority, const int *Pids)
- : cReceiver(ChannelID, Priority, 0, Pids)
+cLiveReceiver::cLiveReceiver(cLiveStreamer *Streamer, const cChannel *Channel, int Priority, const int *Pids)
+ : cReceiver(Channel, Priority)
  , m_Streamer(Streamer)
 {
   DEBUGLOG("Starting live receiver");
@@ -503,7 +503,7 @@ void cLivePatFilter::Process(u_short Pid, u_char Tid, const u_char *Data, int Le
         }
       }
 
-      m_Streamer->m_Receiver  = new cLiveReceiver(m_Streamer, m_Channel->GetChannelID(), m_Streamer->m_Priority, m_Streamer->m_Pids);
+      m_Streamer->m_Receiver  = new cLiveReceiver(m_Streamer, m_Channel, m_Streamer->m_Priority, m_Streamer->m_Pids);
       m_Streamer->m_Device->AttachReceiver(m_Streamer->m_Receiver);
       INFOLOG("Currently unknown new streams found, receiver and demuxers reinited\n");
       m_Streamer->RequestStreamChange();
@@ -624,9 +624,10 @@ void cLiveStreamer::Action(void)
   unsigned char *buf    = NULL;
   m_startup             = true;
 
-  cTimeMs last_tick;
   cTimeMs last_info;
   cTimeMs starttime;
+
+  m_last_tick.Set(0);
 
   while (Running())
   {
@@ -640,19 +641,15 @@ void cLiveStreamer::Action(void)
       break;
     }
 
-    // prevent inifinite loop on encrypted channels
-    if(!IsReady() && (starttime.Elapsed() >= (uint64_t)(m_scanTimeout*1000))) {
-      INFOLOG("returning from streamer thread, timeout on starting streaming");
-      break;
-    }
-
     // no data
     if (buf == NULL || size <= TS_SIZE)
     {
       // keep client going
-      if(last_tick.Elapsed() >= 1000 && !IsReady()) {
-        m_Socket->write(m_packetEmpty->getPtr(), m_packetEmpty->getLen());
-        last_tick.Set(0);
+      if(m_last_tick.Elapsed() >= (uint64_t)(m_scanTimeout*2000) && !m_SignalLost)
+      {
+        INFOLOG("No Signal");
+        m_SignalLost = true;
+        sendStreamStatus();
       }
       continue;
     }
@@ -704,6 +701,7 @@ void cLiveStreamer::Action(void)
       sendSignalInfo();
     }
   }
+  INFOLOG("exit streamer thread");
 }
 
 bool cLiveStreamer::StreamChannel(const cChannel *channel, int priority, cxSocket *Socket, cResponsePacket *resp)
@@ -822,7 +820,7 @@ bool cLiveStreamer::StreamChannel(const cChannel *channel, int priority, cxSocke
       if (m_NumStreams > 0 && m_Socket)
       {
         dsyslog("VNSI: Creating new live Receiver");
-        m_Receiver  = new cLiveReceiver(this, m_Channel->GetChannelID(), m_Priority, m_Pids);
+        m_Receiver  = new cLiveReceiver(this, m_Channel, m_Priority, m_Pids);
         m_PatFilter = new cLivePatFilter(this, m_Channel);
         m_Device->AttachReceiver(m_Receiver);
         m_Device->AttachFilter(m_PatFilter);
@@ -928,6 +926,8 @@ void cLiveStreamer::sendStreamPacket(sStreamPacket *pkt)
 
   m_Socket->write(pkt->data, pkt->size);
 
+  m_last_tick.Set(0);
+  m_SignalLost = false;
 }
 
 void cLiveStreamer::sendStreamChange()
@@ -1206,6 +1206,21 @@ void cLiveStreamer::sendStreamInfo()
     }
   }
 
+  resp->finaliseStream();
+  m_Socket->write(resp->getPtr(), resp->getLen());
+  delete resp;
+}
+
+void cLiveStreamer::sendStreamStatus()
+{
+  cResponsePacket *resp = new cResponsePacket();
+  if (!resp->initStream(VNSI_STREAM_STATUS, 0, 0, 0, 0))
+  {
+    ERRORLOG("stream response packet init fail");
+    delete resp;
+    return;
+  }
+  resp->add_String("No Signal");
   resp->finaliseStream();
   m_Socket->write(resp->getPtr(), resp->getLen());
   delete resp;

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.c
@@ -645,11 +645,12 @@ void cLiveStreamer::Action(void)
     if (buf == NULL || size <= TS_SIZE)
     {
       // keep client going
-      if(m_last_tick.Elapsed() >= (uint64_t)(m_scanTimeout*2000) && !m_SignalLost)
+      if(m_last_tick.Elapsed() >= (uint64_t)(m_scanTimeout*1000))
       {
         INFOLOG("No Signal");
-        m_SignalLost = true;
         sendStreamStatus();
+        m_last_tick.Set(0);
+        m_SignalLost = true;
       }
       continue;
     }
@@ -687,6 +688,8 @@ void cLiveStreamer::Action(void)
       {
         demuxer->ProcessTSPacket(buf);
       }
+      else
+        INFOLOG("no muxer found");
 
       buf += TS_SIZE;
       size -= TS_SIZE;
@@ -799,11 +802,6 @@ bool cLiveStreamer::StreamChannel(const cChannel *channel, int priority, cxSocke
       {
         m_Streams[m_NumStreams] = new cTSDemuxer(this, m_NumStreams, stTELETEXT, m_Channel->Tpid());
         m_Pids[m_NumStreams]    = m_Channel->Tpid();
-        cCamSlot* cam = m_Device->CamSlot();
-        if(cam != NULL) 
-        {
-          cam->AddPid(m_Channel->Sid(), m_Channel->Tpid(), 0x06);
-        }
         m_NumStreams++;
       }
 

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.h
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/receiver.h
@@ -58,6 +58,7 @@ private:
   void sendStreamChange();
   void sendSignalInfo();
   void sendStreamInfo();
+  void sendStreamStatus();
 
   const cChannel   *m_Channel;                      /*!> Channel to stream */
   cDevice          *m_Device;                       /*!> The receiving device the channel depents to */

--- a/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/vnsiclient.c
+++ b/xbmc/pvrclients/vdr-vnsi/vdr-plugin-vnsiserver/vnsiclient.c
@@ -1352,7 +1352,11 @@ bool cVNSIClient::processRECORDINGS_GetList() /* OPCODE 102 */
       }
       else
       {
+#if APIVERSNUM >= 10727
+        recordingStart = recording->Start();
+#else
         recordingStart = recording->start;
+#endif
       }
     }
     DEBUGLOG("GRI: RC: recordingStart=%lu recordingDuration=%i", recordingStart, recordingDuration);
@@ -1364,10 +1368,18 @@ bool cVNSIClient::processRECORDINGS_GetList() /* OPCODE 102 */
     m_resp->add_U32(recordingDuration);
 
     // priority
+#if APIVERSNUM >= 10727
+    m_resp->add_U32(recording->Priority());
+#else
     m_resp->add_U32(recording->priority);
+#endif
 
     // lifetime
+#if APIVERSNUM >= 10727
+    m_resp->add_U32(recording->Lifetime());
+#else
     m_resp->add_U32(recording->lifetime);
+#endif
 
     // channel_name
     m_resp->add_String(recording->Info()->ChannelName() ? m_toUTF8.Convert(recording->Info()->ChannelName()) : "");


### PR DESCRIPTION
Some fixes to vnsi. You may have a closer look into a4920178afeb919e8bc070731f9030892e76594a since tvheadend does the same thing. The abort in demuxer blocks the main thread when waiting on the protected socket.
