### PR TITLE
pvr: parse input stream for decoder parameters

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
@@ -53,7 +53,9 @@ public:
   CDemuxStreamVideoPVRClient(CDVDDemuxPVRClient *parent)
     : m_parent(parent)
   {}
+  virtual ~CDemuxStreamVideoPVRClient();
   virtual void GetStreamInfo(std::string& strInfo);
+  AVCodecParserContext* m_pParser;
 };
 
 class CDemuxStreamAudioPVRClient : public CDemuxStreamAudio
@@ -63,7 +65,9 @@ public:
   CDemuxStreamAudioPVRClient(CDVDDemuxPVRClient *parent)
     : m_parent(parent)
   {}
+  virtual ~CDemuxStreamAudioPVRClient();
   virtual void GetStreamInfo(std::string& strInfo);
+  AVCodecParserContext* m_pParser;
 };
 
 class CDemuxStreamSubtitlePVRClient : public CDemuxStreamSubtitle
@@ -79,6 +83,9 @@ public:
 
 class CDVDDemuxPVRClient : public CDVDDemux
 {
+  friend class CDemuxStreamVideoPVRClient;
+  friend class CDemuxStreamAudioPVRClient;
+
 public:
 
   CDVDDemuxPVRClient();
@@ -104,15 +111,14 @@ protected:
   #define MAX_STREAMS 100
 #endif
   CDemuxStream* m_streams[MAX_STREAMS]; // maximum number of streams that ffmpeg can handle
+  CDemuxStream* m_streamsToParse[MAX_STREAMS];
   boost::shared_ptr<PVR::CPVRClient> m_pvrClient;
 
   DllAvCodec  m_dllAvCodec;
-  AVCodecParserContext* m_pParser;
-  bool m_bNeedExtraData;
 
 private:
   void RequestStreams();
   void UpdateStreams(PVR_STREAM_PROPERTIES *props);
-  bool ParseVideoPacket(DemuxPacket* pPacket);
+  bool ParsePacket(DemuxPacket* pPacket);
 };
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
@@ -22,6 +22,8 @@
 
 #include "DVDDemux.h"
 #include <map>
+#include "DllAvCodec.h"
+#include "DllAvFormat.h"
 
 #ifndef _LINUX
 #include <libavformat/avformat.h>
@@ -104,8 +106,13 @@ protected:
   CDemuxStream* m_streams[MAX_STREAMS]; // maximum number of streams that ffmpeg can handle
   boost::shared_ptr<PVR::CPVRClient> m_pvrClient;
 
+  DllAvCodec  m_dllAvCodec;
+  AVCodecParserContext* m_pParser;
+  bool m_bNeedExtraData;
+
 private:
   void RequestStreams();
   void UpdateStreams(PVR_STREAM_PROPERTIES *props);
+  bool ParseVideoPacket(DemuxPacket* pPacket);
 };
 


### PR DESCRIPTION
Having extra data on pvr stream makes Chrystal HD usable with pvr. I think it's a good idea having elupus a look at this.
