### PR TITLE
PVR and EPG support for profile switching

### DIFF
--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -482,6 +482,14 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   if (!m_bIgnoreDbForClient && !m_database.IsOpen())
   {
     CLog::Log(LOGERROR, "EpgContainer - %s - could not open the database", __FUNCTION__);
+
+    CSingleLock lock(m_critSection);
+    m_bIsUpdating = false;
+    m_updateEvent.Set();
+
+    if (bShowProgress && !bOnlyPending)
+      CloseProgressDialog();
+
     return false;
   }
 

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -269,6 +269,10 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // stop service addons and give it some time before we start it again
   ADDON::CAddonMgr::Get().StopServices(true);
 
+  // stop PVR related services
+  g_application.StopPVRManager();
+  g_application.StopEPGManager();
+
   if (profile != 0 || !g_settings.IsMasterUser())
   {
     g_application.getNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
@@ -303,6 +307,10 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   // start services which should run on login 
   ADDON::CAddonMgr::Get().StartServices(false);
+
+  // start PVR related services
+  g_application.StartEPGManager();
+  g_application.StartPVRManager();
 
   g_windowManager.ChangeActiveWindow(g_SkinInfo->GetFirstWindow());
 


### PR DESCRIPTION
This adds PVR support to XBMC's profiles.

The database creation had to be moved from the constructors to the "start" methods and the closing from the destructors to the "stop" methods. Afterwards there were problems with PVR/EPG database resetting (because the PVR and EPG managers are stopped before the reset and so were the databases) so I had to put some additional checks for opening the databases if needed.

This is a working proof of concept. Maybe there could be a better solution (to create special methods in PVR and EPG managers to open/close the DB and then still call those within the constructor/destructor pairs and also from within the profile switching method).
