### PR TITLE
pvr: added selection of channel groups within channel osd

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -523,6 +523,11 @@ CPVRChannelGroup *CPVRChannelGroup::GetNextGroup(void) const
   return g_PVRChannelGroups->Get(m_bRadio)->GetNextGroup(*this);
 }
 
+CPVRChannelGroup *CPVRChannelGroup::GetPreviousGroup(void) const
+{
+  return g_PVRChannelGroups->Get(m_bRadio)->GetPreviousGroup(*this);
+}
+
 /********** private methods **********/
 
 int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -325,6 +325,11 @@ namespace PVR
     virtual CPVRChannelGroup *GetNextGroup(void) const;
 
     /*!
+     * @return The previous channel group.
+     */
+    virtual CPVRChannelGroup *GetPreviousGroup(void) const;
+
+    /*!
      * @brief The amount of hidden channels in this container.
      * @return The amount of hidden channels in this container.
      */

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -104,6 +104,28 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
       }
     }
     break;
+
+  case GUI_MSG_MOVE:
+    {
+      int iAction = message.GetParam1();
+
+      if (iAction == ACTION_MOVE_RIGHT || iAction == ACTION_MOVE_LEFT)
+      {
+        CPVRChannel channel;
+        g_PVRManager.GetCurrentChannel(channel);
+
+        const CPVRChannelGroup *group = g_PVRManager.GetPlayingGroup(channel.IsRadio());
+        CPVRChannelGroup *nextGroup = iAction == ACTION_MOVE_RIGHT ? group->GetNextGroup() : group->GetPreviousGroup();
+
+        g_PVRManager.SetPlayingGroup(nextGroup);
+
+        Clear();
+        Update();
+
+        return true;
+      }
+    }
+    break;
   }
 
   return CGUIDialog::OnMessage(message);


### PR DESCRIPTION
I added the possibilty to change the channel groups within the channel osd to improve handling of channel groups while watching live tv.

Now you can use left/right key to change the channel group without stopping the current playback.
