### PR TITLE
pvr: fixed GetDirectoryFromPath (was matching incomplete base folder parts)

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -70,7 +70,8 @@ const CStdString CPVRRecordings::GetDirectoryFromPath(const CStdString &strPath,
   /* strip the base or return an empty value if it doesn't fit or match */
   if (!strUseBase.IsEmpty())
   {
-    if (strUsePath.GetLength() <= strUseBase.GetLength() || strUsePath.Left(strUseBase.GetLength()) != strUseBase)
+    /* adding "/" to make sure that base matches the complete folder name and not only parts of it */
+    if (strUsePath.GetLength() <= strUseBase.GetLength() || strUsePath.Left(strUseBase.GetLength() + 1) != strUseBase + "/")
       return strReturn;
     strUsePath.erase(0, strUseBase.GetLength());
   }


### PR DESCRIPTION
Solves an issue in the recordings list by fixing GetDirectoryFromPath.

When having two subfolders 'My favorite Series' and 'My favorite Series - Special', the recordings list shows an empty folder named ' - Special'.
This patch makes sure that GetDirectoryFromPath matches complete folder names and not only parts of it.
