### PR TITLE
pvr: bugfix in 'mark as watched'

### DIFF
--- a/xbmc/addons/include/xbmc_pvr_types.h
+++ b/xbmc/addons/include/xbmc_pvr_types.h
@@ -312,7 +312,7 @@ extern "C" {
     int           iLifetime;            /*!< @brief (optional) life time in days of this recording */
     int           iGenreType;           /*!< @brief (optional) genre type */
     int           iGenreSubType;        /*!< @brief (optional) genre sub type */
-    bool          iPlayCount;           /*!< @brief (optional) play count of this recording on the client */
+    int           iPlayCount;           /*!< @brief (optional) play count of this recording on the client */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -53,7 +53,7 @@ namespace PVR
     int           m_iLifetime;      /*!< lifetime of this recording */
     CStdString    m_strStreamURL;   /*!< stream URL. if empty use pvr client */
     CStdString    m_strDirectory;   /*!< directory of this recording on the client */
-    bool          m_iRecPlayCount;  /*!< play count of this recording on the client */
+    int           m_iRecPlayCount;  /*!< play count of this recording on the client */
 
     CPVRRecording(void);
     CPVRRecording(const PVR_RECORDING &recording, unsigned int iClientId);


### PR DESCRIPTION
This mistake has slipped in by my first version that was using a flag for marking recordings as watched.
The current version uses ints all over the place to store a play count.
