### PR TITLE
pvr: Add 'All recordings' item to recordings view.

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7136,6 +7136,10 @@ msgctxt "#19268"
 msgid "Do not show 'no information available' labels"
 msgstr ""
 
+msgctxt "#19269"
+msgid "* All recordings"
+msgstr ""
+
 msgctxt "#19499"
 msgid "Other/Unknown"
 msgstr ""

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -100,7 +100,8 @@ void CPVRRecordings::GetContents(const CStdString &strDirectory, CFileItemList *
   for (unsigned int iRecordingPtr = 0; iRecordingPtr < m_recordings.size(); iRecordingPtr++)
   {
     CPVRRecording *current = m_recordings.at(iRecordingPtr);
-    if (!IsDirectoryMember(strDirectory, current->m_strDirectory, true))
+    bool directMember = !HasAllRecordingsPathExtension(strDirectory);
+    if (!IsDirectoryMember(RemoveAllRecordingsPathExtension(strDirectory), current->m_strDirectory, directMember))
       continue;
 
     CFileItemPtr pFileItem(new CFileItem(*current));
@@ -188,6 +189,7 @@ void CPVRRecordings::GetSubDirectories(const CStdString &strBase, CFileItemList 
     }
   }
 
+  int subDirectories = results->Size();
   CFileItemList files;
   GetContents(strBase, &files);
 
@@ -206,6 +208,29 @@ void CPVRRecordings::GetSubDirectories(const CStdString &strBase, CFileItemList 
 
   results->Append(files);
 
+  // Add 'All Recordings' item (if we have at least one subdirectory in the list)
+  if (subDirectories > 0)
+  {
+    CStdString strLabel(g_localizeStrings.Get(19269)); // "* All recordings"
+    CFileItemPtr pItem(new CFileItem(strLabel));
+    CStdString strAllPath;
+    if(strUseBase.empty())
+      strAllPath = "pvr://recordings";
+    else
+      strAllPath.Format("pvr://recordings/%s", strUseBase.c_str());
+    pItem->SetPath(AddAllRecordingsPathExtension(strAllPath));
+    pItem->SetSpecialSort(SortSpecialOnTop);
+    pItem->SetLabelPreformated(true);
+    pItem->m_bIsFolder = true;
+    pItem->m_bIsShareOrDrive = false;
+    for(int i=0; i<results->Size(); ++i)
+    {
+      if(pItem->m_dateTime < results->Get(i)->m_dateTime)
+        pItem->m_dateTime = results->Get(i)->m_dateTime;
+    }
+    results->AddFront(pItem, 0);
+  }
+
   if (!strUseBase.IsEmpty())
   {
     CStdString strLabel("..");
@@ -216,6 +241,40 @@ void CPVRRecordings::GetSubDirectories(const CStdString &strBase, CFileItemList 
     results->AddFront(pItem, 0);
   }
   m_strDirectoryHistory.Format("pvr://recordings/%s", strUseBase.c_str());
+}
+
+bool CPVRRecordings::HasAllRecordingsPathExtension(const CStdString &strDirectory)
+{
+  CStdString strUseDir = TrimSlashes(strDirectory);
+  CStdString strAllRecordingsPathExtension(PVR_ALL_RECORDINGS_PATH_EXTENSION);
+
+  if (strUseDir.GetLength() < strAllRecordingsPathExtension.GetLength())
+    return false;
+
+  if (strUseDir.GetLength() == strAllRecordingsPathExtension.GetLength())
+    return strUseDir.Equals(strAllRecordingsPathExtension);
+
+  return strUseDir.Right(strAllRecordingsPathExtension.GetLength() + 1).Equals("/" + strAllRecordingsPathExtension);
+}
+
+CStdString CPVRRecordings::AddAllRecordingsPathExtension(const CStdString &strDirectory)
+{
+  if (HasAllRecordingsPathExtension(strDirectory))
+    return strDirectory;
+
+  CStdString strResult = strDirectory;
+  if (!strDirectory.Right(1).Equals("/"))
+    strResult = strResult + "/";
+
+  return strResult + PVR_ALL_RECORDINGS_PATH_EXTENSION + "/";
+}
+
+CStdString CPVRRecordings::RemoveAllRecordingsPathExtension(const CStdString &strDirectory)
+{
+  if (!HasAllRecordingsPathExtension(strDirectory))
+    return strDirectory;
+
+  return strDirectory.Left(strDirectory.GetLength() - strlen(PVR_ALL_RECORDINGS_PATH_EXTENSION) - 1);
 }
 
 int CPVRRecordings::Load(void)

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -26,6 +26,8 @@
 #include "utils/Observer.h"
 #include "ThumbLoader.h"
 
+#define PVR_ALL_RECORDINGS_PATH_EXTENSION "-1"
+
 namespace PVR
 {
   class CPVRRecordings : public Observable
@@ -43,6 +45,10 @@ namespace PVR
     virtual bool IsDirectoryMember(const CStdString &strDirectory, const CStdString &strEntryDirectory, bool bDirectMember = true) const;
     virtual void GetContents(const CStdString &strDirectory, CFileItemList *results);
     virtual void GetSubDirectories(const CStdString &strBase, CFileItemList *results, bool bAutoSkip = true);
+
+    bool HasAllRecordingsPathExtension(const CStdString &strDirectory);
+    CStdString AddAllRecordingsPathExtension(const CStdString &strDirectory);
+    CStdString RemoveAllRecordingsPathExtension(const CStdString &strDirectory);
 
   public:
     CPVRRecordings(void);


### PR DESCRIPTION
This PR adds an 'All recordings' item on top of the recordings list. (like the one we have for music)
The item is only visible if the current folder has at least one sub directory.

I implemented it in the same way than it is in the music library: by adding a special tag to the url: /-1/.

Having the 'All recordings' item is especially useful when the client creates lots of subfolders.
For example if the client uses subfolders for genres or series.

Let me know what you think about it.
