### PR TITLE
Added transcoing support for TVHeadend servers

### DIFF
--- a/addons/pvr.hts/resources/language/English/strings.xml
+++ b/addons/pvr.hts/resources/language/English/strings.xml
@@ -9,6 +9,15 @@
     <string id="30006">Connect timeout in seconds</string>
     <string id="30007">Response timeout in seconds</string>
 
+    <string id="30008">Enable transcoding</string>
+    <string id="30009">Audio codec</string>
+    <string id="30010">Video codec</string>
+    <string id="30011">Resolution</string>
+
+    <!-- category labels -->
+    <string id="30040">Connection</string>
+    <string id="30041">Transcoding</string>
+
     <!-- notifications -->
     <string id="30500">Disconnected from '%s'</string>
     <string id="30501">Reconnected to '%s'</string>

--- a/addons/pvr.hts/resources/settings.xml
+++ b/addons/pvr.hts/resources/settings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
+  <!-- Connection -->
+  <category label="30040">
     <setting id="host" type="text" label="30000" default="127.0.0.1" />
     <setting id="http_port" type="number" label="30001" default="9981" />
     <setting id="htsp_port" type="number" label="30002" default="9982" />
@@ -7,4 +9,13 @@
     <setting id="pass" type="text" label="30004" option="hidden" default="" />
     <setting id="connect_timeout" type="enum" label="30006" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60" default="29" />
     <setting id="response_timeout" type="enum" label="30007" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60" default="1" />
+  </category>
+
+  <!-- Transcoding -->
+  <category label="30041">
+    <setting id="transcode" type="bool" label="30008" default="false" />
+    <setting id="audio_codec" type="enum" label="30009" values="MPEG2 Audio|AAC" default="1"/>
+    <setting id="video_codec" type="enum" label="30010" values="MPEG2 Video|H264" default="1"/>
+    <setting id="video_res" type="enum" label="30011" values="288p|384p|480p|576p|720p|1080p" default="2"/>
+  </category>
 </settings>

--- a/xbmc/pvrclients/tvheadend/HTSPDemux.cpp
+++ b/xbmc/pvrclients/tvheadend/HTSPDemux.cpp
@@ -444,6 +444,13 @@ bool CHTSPDemux::SendSubscribe(int subscription, int channel)
   htsmsg_add_str(m, "method"        , "subscribe");
   htsmsg_add_s32(m, "channelId"     , channel);
   htsmsg_add_s32(m, "subscriptionId", subscription);
+  if(g_bTranscode)
+  {
+    htsmsg_add_u32(m, "maxWidth"    , 0xffffffff); // Don't care
+    htsmsg_add_u32(m, "maxHeight"   , g_iResolution);
+    htsmsg_add_str(m, "audioCodec"  , g_strAudioCodec.c_str());
+    htsmsg_add_str(m, "videoCodec"  , g_strVideoCodec.c_str());
+  }
   return m_session->ReadSuccess(m, true, "subscribe to channel");
 }
 

--- a/xbmc/pvrclients/tvheadend/client.h
+++ b/xbmc/pvrclients/tvheadend/client.h
@@ -28,6 +28,8 @@
 #define DEFAULT_HTSP_PORT        9982
 #define DEFAULT_CONNECT_TIMEOUT  30
 #define DEFAULT_RESPONSE_TIMEOUT 3
+#define DEFAULT_TRANSCODE        false
+#define DEFAULT_RESOLUTION       480
 
 extern bool                      m_bCreated;
 extern std::string               g_strHostname;
@@ -37,6 +39,10 @@ extern std::string               g_strUsername;
 extern std::string               g_strPassword;
 extern int                       g_iConnectTimeout;
 extern int                       g_iResponseTimeout;
+extern bool                      g_bTranscode;
+extern std::string               g_strAudioCodec;
+extern std::string               g_strVideoCodec;
+extern int                       g_iResolution;
 extern int                       g_iClientId;
 extern unsigned int              g_iPacketSequence;
 extern bool                      g_bShowTimerNotifications;


### PR DESCRIPTION
This patch enables the use of the live transcoding feature I've added to my branch of tvheadend.
It might come in handy for low end hardware like the raspberry pie or cellphones that lack hardware mpeg2 decoders.

The server branch can be cloned from: https://github.com/john-tornblom/tvheadend

The transcoding is performed in software using ffmpeg so the server needs to be running on a rather recent CPU, depending on the resolution configured on the client side.
