### PR TITLE
pvr: Restore current recording subfolder (on UpdateData)

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -197,10 +197,15 @@ void CGUIWindowPVRRecordings::UpdateData(bool bUpdateSelectedFile /* = true */)
   CSingleLock graphicsLock(g_graphicsContext);
 
   m_iSelected = m_parent->m_viewControl.GetSelectedItem();
+  if (m_parent->m_vecItems->GetPath().Left(17) != "pvr://recordings/")
+    m_strSelectedPath = "pvr://recordings/";
+  else
+    m_strSelectedPath = m_parent->m_vecItems->GetPath();
+
   m_parent->m_viewControl.Clear();
   m_parent->m_vecItems->Clear();
   m_parent->m_viewControl.SetCurrentView(m_iControlList);
-  m_parent->m_vecItems->SetPath("pvr://recordings/");
+  m_parent->m_vecItems->SetPath(m_strSelectedPath);
   m_parent->Update(m_strSelectedPath);
   m_parent->m_viewControl.SetItems(*m_parent->m_vecItems);
 


### PR DESCRIPTION
The recording list currently does not save it's state when the client updates it's data.
It will always go back to the root folder. (also mentioned in issue #435)
With this patch, the list will stay in the current folder and the selected item is preserved. 

I'm using this patch for quite a while now (with tsp's mythtv client). 
As stated in #435, it's not perfect because I don't know how to preserve the scrollbar position.
However it definitively improves the current behavior and makes the recordings list with subfolders much more useable. Therefore I think it's worth beeing added to the main pvr branch.

Let me know what you think. If there's an easy fix for the scrollbar, please let me know. I'd be happy to include it in my patch.
