### PR TITLE
Add new playlist types and set them when starting live tv

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4254,6 +4254,9 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 #if !defined(TARGET_DARWIN) && !defined(_LINUX)
     g_audioManager.Enable(false);
 #endif
+
+    if (item.HasPVRChannelInfoTag())
+      g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
   }
   m_bPlaybackStarting = false;
 


### PR DESCRIPTION
Currently the PVR doesn't set any playerlist id when starting to play. This means for example that JSON client always get different playerids when starting to play a channel (-1 for none after starting XBMC, 0 when the last active player was an audio player etc). This will add two playlist types, PVRRADIO and PVRTV, and one of them will be set depending on whether the channel of which the playback is started is a radio or tv channel. I choose to split them in radio and tv for extra clarity, but if you want them to be merged in a single type it's fine with me. I at least would like to have a distinction between the normals players (audio/video) and PVR so JSON clients as a remote app for smartphones are able to make a distinction so they could show a channel up/down button instead of previous/next etc.
