### PR TITLE
No focus on Find similar programme

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -848,7 +848,7 @@ bool CGUIWindowPVRCommon::OnContextButtonFind(CFileItem *item, CONTEXT_BUTTON bu
 
       m_parent->m_windowSearch->m_bSearchConfirmed = true;
       m_parent->SetLabel(m_iControlButton, 0);
-      m_parent->SetActiveView(m_parent->m_windowSearch);
+      m_parent->m_viewControl.SetCurrentView(CONTROL_LIST_SEARCH);
       m_parent->m_windowSearch->UpdateData();
       m_parent->SetLabel(m_iControlList, 0);
     }


### PR DESCRIPTION
When Find similar programme button in Context menu on Guide view is clicked, Search list opens with search results, but there is no focus on search result list.
If you are using XBMC without the mouse there is no way you can browse search results.

This small change fixes that.
