### PR TITLE
EPG - improve GoToEnd and GoToBegin functions in CGUIEPGGridContainer

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1627,11 +1627,31 @@ void CGUIEPGGridContainer::Reset()
 void CGUIEPGGridContainer::GoToBegin()
 {
   ScrollToBlockOffset(0);
+  SetBlock(0);
 }
 
 void CGUIEPGGridContainer::GoToEnd()
 {
-  ScrollToBlockOffset(m_blocks - m_blocksPerPage);
+  int blocksEnd = 0;   // the end block of the last epg element for the selected channel
+  int blocksStart = 0; // the start block of the last epg element for the selected channel
+  int blockOffset = 0; // the block offset to scroll to
+  for (int blockIndex = m_blocks; blockIndex>=0; blockIndex--)
+  {
+    if (!blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blockIndex].item != NULL)
+      blocksEnd = blockIndex;
+    if (blocksEnd && m_gridIndex[m_channelCursor + m_channelOffset][blocksEnd].item != 
+                     m_gridIndex[m_channelCursor + m_channelOffset][blockIndex].item)
+      blocksStart = blockIndex + 1;
+    if (blocksEnd && blocksStart)
+      break;
+  }
+  if (blocksEnd - blocksStart > m_blocksPerPage)
+    blockOffset = blocksStart;
+  else if (blocksEnd > m_blocksPerPage)
+    blockOffset = blocksEnd - m_blocksPerPage;
+
+  ScrollToBlockOffset(blockOffset); // scroll to the start point of the last epg element
+  SetBlock(m_blocksPerPage - 1);    // select the last epg element
 }
 
 void CGUIEPGGridContainer::SetStartEnd(CDateTime start, CDateTime end)


### PR DESCRIPTION
The current "go to end" function in epg grid is far from ideal. It always scrolls to the maximum block even if the selected channel doesn't have any epg for that time interval.

This commit improves the GoToEnd() method so that it always scrolls to the beginning of the last epg item of the selected channel. It also puts focus to the last item.

The GoToBegin() method now also puts focus to the first item of the selected channel.
