### PR TITLE
[win32] build and add pvr.demo

### DIFF
--- a/addons/pvr.demo/addon.xml
+++ b/addons/pvr.demo/addon.xml
@@ -9,11 +9,13 @@
   </requires>
   <extension
     point="xbmc.pvrclient"
-    library_linux="XBMC_demo.pvr" />
+    library_linux="XBMC_demo.pvr"
+    library_wingl="XBMC_demo_win32.pvr"
+    library_windx="XBMC_demo_win32.pvr" />
   <extension point="xbmc.addon.metadata">
     <summary>Pulse-Eight Demo PVR Client</summary>
     <description>Pulse-Eight Demo PVR Client</description>
     <disclaimer>Just contains stubs</disclaimer>
-    <platform>linux</platform>
+    <platform>linux wingl windx</platform>
   </extension>
 </addon>

--- a/project/VS2010Express/XBMC for Windows.sln
+++ b/project/VS2010Express/XBMC for Windows.sln
@@ -102,6 +102,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XbmcThreads", "XbmcThreads.
 		{87DA0A1E-3F33-4927-A5E5-2D58F2C58E17} = {87DA0A1E-3F33-4927-A5E5-2D58F2C58E17}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pvrclient_demo", "..\..\xbmc\pvrclients\pvr-demo\Project\VS2010Express\XBMC_pvrdemo\XBMC_pvrdemo.vcxproj", "{7E4439C4-C7DD-4169-B5BC-B7B459330877}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug (DirectX)|Win32 = Debug (DirectX)|Win32

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1095,7 +1095,7 @@ bool CPVRClients::OpenStream(const CPVRChannel &tag)
 
     if (tag.ClientID() == PVR_VIRTUAL_CLIENT_ID)
       m_strPlayingClientName = g_localizeStrings.Get(19209);
-    else if (!tag.IsVirtual())
+    else if (!tag.IsVirtual() && client.get())
       m_strPlayingClientName = client->GetFriendlyName();
     else
       m_strPlayingClientName = g_localizeStrings.Get(13205);

--- a/xbmc/pvrclients/MediaPortal/pvrclient-mediaportal.cpp
+++ b/xbmc/pvrclients/MediaPortal/pvrclient-mediaportal.cpp
@@ -668,11 +668,11 @@ PVR_ERROR cPVRClientMediaPortal::GetChannels(PVR_HANDLE handle, bool bRadio)
         strIconName = strThumbPath + ToThumbFileName(channel.Name()) + ".png";
         if ( OS::CFile::Exists(strIconName) )
         {
-          tag.strIconPath = strIconName.c_str();
+          memcpy(tag.strIconPath, strIconName.c_str(), sizeof(tag.strIconPath));
         }
         else
         {
-          tag.strIconPath = "";
+          memset(tag.strIconPath, 0, sizeof(tag.strIconPath));
         }
       }
 #else

--- a/xbmc/pvrclients/pvr-demo/PVRDemoData.cpp
+++ b/xbmc/pvrclients/pvr-demo/PVRDemoData.cpp
@@ -27,6 +27,47 @@
 using namespace std;
 using namespace ADDON;
 
+#ifdef TARGET_WINDOWS
+bool XMLUtils::GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
+  if (!pNode || !pNode->FirstChild()) return false;
+  iIntValue = atoi(pNode->FirstChild()->Value());
+  return true;
+}
+
+bool XMLUtils::GetBoolean(const TiXmlNode* pRootNode, const char* strTag, bool& bBoolValue)
+{
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
+  if (!pNode || !pNode->FirstChild()) return false;
+  CStdString strEnabled = pNode->FirstChild()->Value();
+  strEnabled.ToLower();
+  if (strEnabled == "off" || strEnabled == "no" || strEnabled == "disabled" || strEnabled == "false" || strEnabled == "0" )
+    bBoolValue = false;
+  else
+  {
+    bBoolValue = true;
+    if (strEnabled != "on" && strEnabled != "yes" && strEnabled != "enabled" && strEnabled != "true")
+      return false; // invalid bool switch - it's probably some other string.
+  }
+  return true;
+}
+
+bool XMLUtils::GetString(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue)
+{
+  const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag );
+  if (!pElement) return false;
+  const TiXmlNode* pNode = pElement->FirstChild();
+  if (pNode != NULL)
+  {
+    strStringValue = pNode->Value();
+    return true;
+  }
+  strStringValue.Empty();
+  return false;
+}
+#endif
+
 PVRDemoData::PVRDemoData(void)
 {
   m_iEpgStart = -1;
@@ -44,7 +85,17 @@ PVRDemoData::~PVRDemoData(void)
 
 std::string PVRDemoData::GetSettingsFile() const
 {
+#ifdef TARGET_WINDOWS
+  string settingFile = getenv("XBMC_HOME");
+  if (settingFile.at(settingFile.size() - 1) == '\\' ||
+      settingFile.at(settingFile.size() - 1) == '/')
+    settingFile.append("system/PVRDemoAddonSettings.xml");
+  else
+    settingFile.append("/system/PVRDemoAddonSettings.xml");
+  return settingFile;
+#elif
   return CSpecialProtocol::TranslatePath("special://xbmc/system/PVRDemoAddonSettings.xml");
+#endif
 }
 
 bool PVRDemoData::LoadDemoData(void)

--- a/xbmc/pvrclients/pvr-demo/Project/VS2010Express/XBMC_pvrdemo/XBMC_pvrdemo.vcxproj
+++ b/xbmc/pvrclients/pvr-demo/Project/VS2010Express/XBMC_pvrdemo/XBMC_pvrdemo.vcxproj
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\client.h" />
+    <ClInclude Include="..\..\..\PVRDemoData.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\..\..\addons\library.xbmc.addon\dlfcn-win32.cpp" />
+    <ClCompile Include="..\..\..\client.cpp" />
+    <ClCompile Include="..\..\..\PVRDemoData.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>pvrclient_demo</ProjectName>
+    <ProjectGuid>{7E4439C4-C7DD-4169-B5BC-B7B459330877}</ProjectGuid>
+    <RootNamespace>XBMC_demo</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\..\..\..\..\addons\pvr.demo\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Debug\</IntDir>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</IgnoreImportLibrary>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <PostBuildEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</PostBuildEventUseInBuild>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\..\..\..\addons\pvr.demo\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Release\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">XBMC_demo_win32</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.pvr</TargetExt>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">XBMC_demo_win32</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.pvr</TargetExt>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\..\..\project\BuildDependencies\lib\;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\..\..\project\BuildDependencies\lib\;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\..\xbmc\addons\include\;$(SolutionDir)\..\..\xbmc\;$(SolutionDir)\..\..\xbmc\win32\;$(SolutionDir)\..\..\project\BuildDependencies\include\</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_WIN32;_DEBUG;_WINDOWS;;TARGET_WINDOWS;_SECURE_SCL=0;_HAS_ITERATOR_DEBUGGING=0;_WINSOCKAPI_;_USE_32BIT_TIME_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <OutputFile>..\..\..\..\..\..\addons\pvr.demo\XBMC_demo_win32.pvr</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(OutDir)XBMC_demo.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <ImportLibrary>$(OutDir)XBMC_demo.lib</ImportLibrary>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\..\xbmc\addons\include\;$(SolutionDir)\..\..\xbmc\;$(SolutionDir)\..\..\xbmc\win32\;$(SolutionDir)\..\..\project\BuildDependencies\include\</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_WIN32;_WINDOWS;TARGET_WINDOWS;_WINSOCKAPI_;_USE_32BIT_TIME_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <OutputFile>..\..\..\..\..\addons\pvr.team-mediaportal.tvserver\XBMC_demo_win32.pvr</OutputFile>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(OutDir)XBMC_demo.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>
+      </OptimizeReferences>
+      <EnableCOMDATFolding>
+      </EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <ImportLibrary>$(OutDir)XBMC_demo.lib</ImportLibrary>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/xbmc/pvrclients/pvr-demo/client.cpp
+++ b/xbmc/pvrclients/pvr-demo/client.cpp
@@ -26,6 +26,10 @@
 using namespace std;
 using namespace ADDON;
 
+#ifdef TARGET_WINDOWS
+#define snprintf _snprintf
+#endif
+
 bool           m_bCreated       = false;
 ADDON_STATUS   m_CurStatus      = ADDON_STATUS_UNKNOWN;
 PVRDemoData   *m_data           = NULL;


### PR DESCRIPTION
Had to copy code from xbmc code (xmlutils) / workaround calling xbmc methods (translatePath) to "fix" unresolved symbols errors. Not really pretty, but here's alternatives:
- add half of xbmc source to new pvr.demo project (really our includes is mess sometimes)
- move most xbmc code to common lib project and build both pvr addons and xbmc_app against it (lot of shuffling + it would be painful to sync with xbmc master)
