### PR TITLE
GUIWindowPVRGuide - replace clear+copy with assign

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -238,8 +238,7 @@ void CGUIWindowPVRGuide::UpdateViewTimeline(bool bUpdateSelectedFile)
   }
 
   m_parent->m_vecItems->RemoveDiscCache(m_parent->GetID());
-  m_parent->m_vecItems->Clear();
-  m_parent->m_vecItems->Copy(*m_cachedTimeline);
+  m_parent->m_vecItems->Assign(*m_cachedTimeline, false);
 
   CDateTime gridStart = CDateTime::GetCurrentDateTime().GetAsUTCDateTime();
   CDateTime firstDate(g_EpgContainer.GetFirstEPGDate());


### PR DESCRIPTION
Why is it needed to use Copy? It duplicates all items in memory which results in memory leaks when switching between pvr views.

I agree that the correct fix would be finding the leak. But it could be way down in GUIMediaWindow or even deeper...

Valgrind log:

```
==31853== 324,875 (11,472 direct, 313,403 indirect) bytes in 478 blocks are definitely lost in loss record 1,593 of 1,596
==31853==    at 0x4C2B1C7: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==31853==    by 0xF6353C: CFileItemList::Copy(CFileItemList const&) (shared_count.hpp:87)
==31853==    by 0x8CFAFD: PVR::CGUIWindowPVRGuide::UpdateViewTimeline(bool) (GUIWindowPVRGuide.cpp:242)
==31853==    by 0x8D0E2B: PVR::CGUIWindowPVRGuide::UpdateData(bool) (GUIWindowPVRGuide.cpp:285)
==31853==    by 0x8CDA93: PVR::CGUIWindowPVRGuide::OnClickButton(CGUIMessage&) (GUIWindowPVRGuide.cpp:335)
==31853==    by 0x8C5B68: PVR::CGUIWindowPVR::OnMessageClick(CGUIMessage&) (GUIWindowPVR.cpp:210)
==31853==    by 0x8C5DA6: PVR::CGUIWindowPVR::OnMessage(CGUIMessage&) (GUIWindowPVR.cpp:127)
==31853==    by 0x8EEED0: CGUIButtonControl::OnClick() (GUIButtonControl.cpp:312)
==31853==    by 0x8EDA10: CGUIButtonControl::OnAction(CAction const&) (GUIButtonControl.cpp:144)
==31853==    by 0x972EEF: CGUIWindow::OnAction(CAction const&) (GUIWindow.cpp:389)
==31853==    by 0xF082FD: CGUIMediaWindow::OnAction(CAction const&) (GUIMediaWindow.cpp:174)
==31853==    by 0x97869C: CGUIWindowManager::OnAction(CAction const&) (GUIWindowManager.cpp:484)
==31853== 
==31853== 6,943,293 (240,888 direct, 6,702,405 indirect) bytes in 10,037 blocks are definitely lost in loss record 1,596 of 1,596
==31853==    at 0x4C2B1C7: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==31853==    by 0xF6353C: CFileItemList::Copy(CFileItemList const&) (shared_count.hpp:87)
==31853==    by 0x8CFAFD: PVR::CGUIWindowPVRGuide::UpdateViewTimeline(bool) (GUIWindowPVRGuide.cpp:242)
==31853==    by 0x8D0E2B: PVR::CGUIWindowPVRGuide::UpdateData(bool) (GUIWindowPVRGuide.cpp:285)
==31853==    by 0x8CA34F: PVR::CGUIWindowPVRCommon::OnMessageFocus(CGUIMessage&) (GUIWindowPVRCommon.cpp:179)
==31853==    by 0x8C5D09: PVR::CGUIWindowPVR::OnMessageFocus(CGUIMessage&) (GUIWindowPVR.cpp:191)
==31853==    by 0x8C5D7C: PVR::CGUIWindowPVR::OnMessage(CGUIMessage&) (GUIWindowPVR.cpp:127)
==31853==    by 0x9019F1: CGUIControlGroup::OnMessage(CGUIMessage&) (GUIControlGroup.cpp:227)
==31853==    by 0x9019F1: CGUIControlGroup::OnMessage(CGUIMessage&) (GUIControlGroup.cpp:227)
==31853==    by 0x8F5945: CGUIControl::OnMessage(CGUIMessage&) (GUIControl.cpp:328)
==31853==    by 0x975E63: CGUIWindow::OnMessage(CGUIMessage&) (GUIWindow.cpp:609)
==31853==    by 0xF09D0A: CGUIMediaWindow::OnMessage(CGUIMessage&) (GUIMediaWindow.cpp:512)
```
