### PR TITLE
Show full screen video information even if stream isn't working

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3063,7 +3063,7 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow, CStdString *fa
   }
   else if (info == VIDEOPLAYER_COVER)
   {
-    if (!g_application.IsPlayingVideo()) return "";
+    if (!g_application.IsPlayingVideo() && !m_currentFile->HasPVRChannelInfoTag()) return "";
     if (fallback)
       *fallback = "DefaultVideoCover.png";
     if(m_currentMovieThumb.IsEmpty())
@@ -3515,7 +3515,7 @@ CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
 
 CStdString CGUIInfoManager::GetVideoLabel(int item)
 {
-  if (!g_application.IsPlayingVideo())
+  if (!g_application.IsPlayingVideo() && !m_currentFile->HasPVRChannelInfoTag())
     return "";
 
   if (item == VIDEOPLAYER_TITLE)


### PR DESCRIPTION
Currently XBMC doesn't show info in fullscreen when a stream isn't playing (scrambled on satellite, not subscribed on iptv, ...) which is quite confusing. If you have a few non working channels one after another you can easily get confused on what should be currently playing.

This simple commit fixes that problem.
