### PR TITLE
epg: fix a bug in the 'current event changed' checking

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -256,7 +256,9 @@ bool CEpg::CheckPlayingEvent(void)
   bool bGotPreviousTag = InfoTagNow(previousTag, false);
   bool bGotCurrentTag = InfoTagNow(newTag);
 
-  if (!bGotPreviousTag || (bGotCurrentTag && previousTag != newTag))
+  bool bTagChanged = bGotCurrentTag && (!bGotPreviousTag || previousTag != newTag);
+  bool bTagRemoved = !bGotCurrentTag && bGotPreviousTag;
+  if (bTagChanged || bTagRemoved)
   {
     NotifyObservers(ObservableMessageEpgActiveItem);
     bReturn = true;


### PR DESCRIPTION
Fixes a bug where on channels without events (radio for example) it would always detect the events as having changed. As I already noted on IRC a couple of days ago.

The fix makes sure there is a new current playing event, which was the bug. On radio channels there is no previous event, thus bGotPreviousTag was false, which was being inverted to true and the if would be true.
