### PR TITLE
pvr: revert some of the changes to old HTSP client

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -68,8 +68,6 @@ public:
     virtual bool SelectChannelByNumber(unsigned int channel) = 0;
     virtual bool SelectChannel(const PVR::CPVRChannel &channel) { return false; };
     virtual bool GetSelectedChannel(PVR::CPVRChannelPtr&) { return false; };
-    virtual int GetTotalTime() = 0;
-    virtual int GetStartTime() = 0;
     virtual bool UpdateItem(CFileItem& item) = 0;
     virtual bool CanRecord() = 0;
     virtual bool IsRecording() = 0;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.cpp
@@ -253,36 +253,9 @@ bool CDVDInputStreamHTSP::UpdateItem(CFileItem& item)
 
 int CDVDInputStreamHTSP::GetTotalTime()
 {
-  if(m_event.id == 0)
-    return 0;
-
-  long duration = (time_t)m_event.stop - (time_t)m_event.start;
-  CDateTimeSpan time = CDateTimeSpan(0, 0, duration / 60, duration % 60);
-
-  return time.GetDays()    * 1000 * 60 * 60 * 24
-       + time.GetHours()   * 1000 * 60 * 60
-       + time.GetMinutes() * 1000 * 60
-       + time.GetSeconds() * 1000;
-}
-
-int CDVDInputStreamHTSP::GetStartTime()
-{
-  if(m_event.id == 0)
-    return 0;
-
-  time_t time_c;
-
-  CDateTime::GetCurrentDateTime().GetAsTime(time_c);
-
-  return (m_event.start - time_c) * 1000;
-}
-
-/*
-int CDVDInputStreamHTSP::GetTotalTime()
-{
-  if(m_event.id == 0)
-    return 0;
-  return (m_event.stop - m_event.start) * 1000;
+    if(m_event.id == 0)
+        return 0;
+    return (m_event.stop - m_event.start) * 1000;
 }
 
 int CDVDInputStreamHTSP::GetTime()
@@ -296,7 +269,6 @@ int CDVDInputStreamHTSP::GetTime()
        + time.GetMinutes() * 1000 * 60
        + time.GetSeconds() * 1000;
 }
-*/
 
 void CDVDInputStreamHTSP::Abort()
 {

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.h
@@ -26,6 +26,7 @@
 class CDVDInputStreamHTSP
   : public CDVDInputStream
   , public CDVDInputStream::IChannel
+  , public CDVDInputStream::IDisplayTime
 {
 public:
   CDVDInputStreamHTSP();
@@ -54,7 +55,7 @@ public:
   bool            Record(bool bOnOff) { return false; }
 
   int             GetTotalTime();
-  int             GetStartTime();
+  int             GetTime();
 
   htsmsg_t* ReadStream();
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -226,7 +226,7 @@ int CDVDInputStreamPVRManager::GetTotalTime()
   return 0;
 }
 
-int CDVDInputStreamPVRManager::GetStartTime()
+int CDVDInputStreamPVRManager::GetTime()
 {
   if (m_pLiveTV)
     return m_pLiveTV->GetStartTime();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -39,6 +39,7 @@ class IDVDPlayer;
 class CDVDInputStreamPVRManager
   : public CDVDInputStream
   , public CDVDInputStream::IChannel
+  , public CDVDInputStream::IDisplayTime
 {
 public:
   CDVDInputStreamPVRManager(IDVDPlayer* pPlayer);
@@ -60,7 +61,7 @@ public:
   bool            GetSelectedChannel(PVR::CPVRChannelPtr& channel) const;
 
   int             GetTotalTime();
-  int             GetStartTime();
+  int             GetTime();
 
   bool            CanRecord();
   bool            IsRecording();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3837,7 +3837,7 @@ void CDVDPlayer::UpdatePlayState(double timeout)
     }
 
     CDVDInputStream::IDisplayTime* pDisplayTime = dynamic_cast<CDVDInputStream::IDisplayTime*>(m_pInputStream);
-    if (pDisplayTime)
+    if (pDisplayTime && pDisplayTime->GetTotalTime() > 0)
     {
       state.time       = pDisplayTime->GetTime();
       state.time_total = pDisplayTime->GetTotalTime();
@@ -3858,15 +3858,6 @@ void CDVDPlayer::UpdatePlayState(double timeout)
       {
         state.time      -= ((CDVDInputStreamTV*)m_pInputStream)->GetStartTime();
         state.time_total = ((CDVDInputStreamTV*)m_pInputStream)->GetTotalTime();
-      }
-    }
-    else if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
-    {
-      if(((CDVDInputStreamPVRManager*)m_pInputStream)->GetTotalTime() > 0 &&
-         ((CDVDInputStreamPVRManager*)m_pInputStream)->GetStartTime() > 0)
-      {
-        state.time       = ((CDVDInputStreamPVRManager*)m_pInputStream)->GetStartTime();
-        state.time_total = ((CDVDInputStreamPVRManager*)m_pInputStream)->GetTotalTime();
       }
     }
   }


### PR DESCRIPTION
This also makes PVR manager use IDisplayTime which simplifies code in dvdplayer.

The changes seemingly made no sense, and this simplifies code.

Note, there is a bug here. GetStartTIme() originally meant: how much time has elapses from the time we started playing this channel and the start of the current playing program. MythTv file still uses this definition but PVRManager does not. So if PVRManager ever uses MythTv as a backing file, it will be wrong.
